### PR TITLE
Uspto fix 40/41

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ Please note that active_failover=1, is the only deterministic method to failover
 
 ## How to configure PXC Scheduler Handler
 There are many options that can be set, and I foresee we will have to add even more. Given that I have abandoned the previous style of using command line and move to config-file definition. Yes this is a bit more expensive, given the file access but it is minimal.
+Keep in mind I am following the CamelCase go standard, for variables and configuration variables as well.
+Said that, the variables in the configuration file are not case sensitive.
+Given that `singlePrimary` or `Singleprimary` or `singleprimary` will be the same. But I suggest you to keep the CamelCase. 
 
 First let us see what we have:
 - 3 sections
@@ -195,7 +198,6 @@ First let us see what we have:
     
 ### Global
 ```[global]
-debug = true
 logLevel = "debug"
 logTarget = "stdout" #stdout | file
 logFile = "/Users/marcotusa/work/temp/pscheduler.log"
@@ -205,10 +207,9 @@ performance = true
 OS = "na"
 ```
 
-- debug : [false] will active some additional features to debug locally as more verbose logs
 - daemonize : [false] Will allow the script to run in a loop without the need to be call by ProxySQL scheduler 
 - daemonInterval : Define in ms the time for looping when in daemon mode
-- loglevel : [error] Define the log level to be used 
+- loglevel : [info] options are: `[error,warning,info,debug]` Define the log level to be used. When using `debug` it will print additional information on the execution, and it can be very verbose.  
 - logTarget : [stdout] Can be either a file or stdout 
 - logFile : In case file for loging define the target 
 - OS : for future use

--- a/config/config-cluster-example.toml
+++ b/config/config-cluster-example.toml
@@ -34,7 +34,6 @@ lockfilepath ="/var/run/"
 
 
 [global]
-debug = true
 logLevel = "info"
 logTarget = "file" #stdout | file
 logFile = "/var/log/pscheduler.log"

--- a/config/config-daemon-example.toml
+++ b/config/config-daemon-example.toml
@@ -30,7 +30,6 @@ lockfilepath ="/var/run/"
 
 
 [global]
-debug = true
 logLevel = "info"
 logTarget = "file" #stdout | file
 logFile = "/var/log/pscheduler.log"

--- a/config/config.toml
+++ b/config/config.toml
@@ -33,7 +33,6 @@ lockfilepath ="/var/run/pxc_scheduler_handler"
 respectManualOfflineSoft=false
 
 [global]
-debug = true
 logLevel = "info"
 logTarget = "stdout" #stdout | file
 logFile = "/var/log/pxc_scheduler_handler/pscheduler.log"

--- a/internal/DataObjects/dataObjects.go
+++ b/internal/DataObjects/dataObjects.go
@@ -257,7 +257,10 @@ func (cluster *DataClusterImpl) init(config global.Configuration, connectionProx
 		global.SetPerformanceObj("data_cluster_init", true, log.InfoLevel)
 	}
 	//set parameters from the config file
-	cluster.Debug = config.Global.Debug
+	if log.GetLevel() == log.DebugLevel {
+		cluster.Debug = true
+	}
+
 	cluster.ClusterIdentifier = config.Pxcluster.ClusterId
 	cluster.CheckTimeout = config.Pxcluster.CheckTimeOut
 	cluster.MainSegment = config.Pxcluster.MainSegment
@@ -1348,10 +1351,11 @@ func (cluster *DataClusterImpl) processUpActionMap() {
 		//While evaluating the nodes that are coming up we also check if it is a Failover Node
 		var hgI int
 		var portI = 0
+		var ipaddress = ""
 		currentHg := cluster.Hostgroups[node.HostgroupId]
 		hg := key[0:strings.Index(key, "_")]
-		ip := key[strings.Index(key, "_")+1 : strings.Index(key, ":")]
-		port := key[strings.Index(key, ":")+1:]
+		ipaddress = string(key[len(hg)+1:len(key)])
+		ip, port, _ := net.SplitHostPort(ipaddress)
 		hgI = global.ToInt(hg)
 		portI = global.ToInt(port)
 		// We process only WRITERS
@@ -1460,10 +1464,11 @@ func (cluster *DataClusterImpl) processDownActionMap() {
 	for key, node := range cluster.ActionNodes {
 		var hgI int
 		var portI = 0
+		var ipaddress = ""
 		currentHg := cluster.Hostgroups[node.HostgroupId]
 		hg := key[0:strings.Index(key, "_")]
-		ip := key[strings.Index(key, "_")+1 : strings.Index(key, ":")]
-		port := key[strings.Index(key, ":")+1:]
+		ipaddress = string(key[len(hg)+1:len(key)])
+		ip, port, _ := net.SplitHostPort(ipaddress)
 		hgI = global.ToInt(hg)
 		portI = global.ToInt(port)
 

--- a/internal/Global/configuration.go
+++ b/internal/Global/configuration.go
@@ -121,7 +121,7 @@ func GetConfig(path string) Configuration {
 	var config Configuration
 	config.fillDefaults()
 	if _, err := toml.DecodeFile(path, &config); err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		syscall.Exit(2)
 	}
 	return config

--- a/internal/Global/configuration.go
+++ b/internal/Global/configuration.go
@@ -147,7 +147,7 @@ func (conf *Configuration) SanityCheck() bool {
 	//check for HG consistency
 	// here HG and backup HG must match
 
-	if conf.Pxcluster.BckHgW >= 0 || conf.Pxcluster.BckHgR >= 0 {
+	if conf.Pxcluster.BckHgW > 0 || conf.Pxcluster.BckHgR > 0 {
 		log.SetReportCaller(false)
 		log.Warning(fmt.Sprintf("Configuration hostgroups (BckHgW & BckHgR) options are DEPRECATED Please configure only ConfigHgRange instead. IE HGw=%d, HGr=%d, ConfigHgRange=%d",
 			conf.Pxcluster.HgW,
@@ -159,6 +159,9 @@ func (conf *Configuration) SanityCheck() bool {
 
 //		return false
 		//os.Exit(1)
+	} else{
+		conf.Pxcluster.BckHgW = conf.Pxcluster.ConfigHgRange + conf.Pxcluster.HgW
+		conf.Pxcluster.BckHgR = conf.Pxcluster.ConfigHgRange + conf.Pxcluster.HgR
 	}
 
 	//Check for correct LockFilePath


### PR DESCRIPTION
Fixed:
- Fixed a logic bug in the sanity check that was printing a warning without reason.
- Fixed a IPv6 issue in parsing the IP when moving up and down a node
- Updated documentation about variable case sensitivity
- Modified default config to have INFO log level and not debug
- Updated documentation to clarify different log levels
- Modified error handling when loading config file to be print with [ERROR] tag
