### PR TITLE
Issue 47

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,9 @@ OS = "na"
 - logTarget : [stdout] Can be either a file or stdout 
 - logFile : In case file for logging define the target 
 - OS : for future use
--  lockfiletimeout  Time ins seconds after which the file lock is considered expired [local instance lock]
--  lockclustertimeout Time in seconds after which the cluster lock is considered expired
+- lockfiletimeout : Time ins seconds after which the file lock is considered expired [local instance lock]
+- lockclustertimeout : Time in seconds after which the cluster lock is considered expired
+- performance : boolean which enable the statistic reporting. If you do not want any reporting just set to `false`. By default, is true which means when log is set as `error` or `warning` you still have: `[INFO]:2022-01-12 16:57:15 - Phase: main = 83,051,000 us 83 ms`
 
 ### ProxySQL
 - port : [6032] Port used to connect 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ OS = "na"
 - daemonInterval : Define in ms the time for looping when in daemon mode
 - loglevel : [info] options are: `[error,warning,info,debug]` Define the log level to be used. When using `debug` it will print additional information on the execution, and it can be very verbose.  
 - logTarget : [stdout] Can be either a file or stdout 
-- logFile : In case file for loging define the target 
+- logFile : In case file for logging define the target 
 - OS : for future use
 -  lockfiletimeout  Time ins seconds after which the file lock is considered expired [local instance lock]
 -  lockclustertimeout Time in seconds after which the cluster lock is considered expired
@@ -243,8 +243,8 @@ OS = "na"
 - singlePrimary : [true] This is the recommended way, always use Galera in Single Primary to avoid write conflicts
 - maxNumWriters : [1] If SinglePrimary is false you can define how many nodes to have as Writers at the same time
 - writerIsAlsoReader : [1] Possible values 0 - 1. The default is 1, if you really want to exclude the writer from read set it to 0. When the cluster will lose its last reader, the writer will be elected as Reader, no matter what. 
-- retryUp : [0] Number of retry the script should do before restoring a failed node
-- retryDown : [0] Number of retry the script should do to put DOWN a failing node
+- retryUp : [0] Number of retries the application should do before restoring a failed node
+- retryDown : [0] Number of retries the application should do to put DOWN a failing node
 - clusterId : 10 the ID for the cluster 
 - persistPrimarySettings : [0]{0|1|2} This option allow the new elected Primary (in case of fail-over) to maintain the Primary node values for weight/connections/Max values and so on.
   (see Persist Primary section for explanation) - valid value 0|1 only Writer|2 Writer and Reader

--- a/config/config.toml
+++ b/config/config.toml
@@ -3,7 +3,7 @@
 activeFailover = 1
 failBack = false
 checkTimeOut = 2000
-# debug = 1 //Deprecated: this is redundant and not in use
+
 mainSegment = 0
 sslClient = "client-cert.pem"
 sslKey = "client-key.pem"
@@ -13,8 +13,7 @@ hgW = 100
 hgR = 101
 configHgRange =8000
 maintenanceHgRange =9000
-bckHgW = 8100 #deprecated
-bckHgR = 8101 #deprecated
+
 singlePrimary = true
 maxNumWriters = 1
 writerIsAlsoReader = 1

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,4 +1,4 @@
-#v.1.3.1
+#v.1.3.2
 [pxccluster]
 activeFailover = 1
 failBack = false

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,9 @@ module pxc_scheduler_handler
 go 1.17
 
 require (
+	github.com/BurntSushi/toml v0.4.1
 	github.com/Tusamarco/toml v0.3.1
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/sirupsen/logrus v1.8.0
 	golang.org/x/text v0.3.6
-	github.com/magefile/mage v1.10.0 // indirect
-	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
+github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Tusamarco/toml v0.3.1 h1:KG1bwBSJ1vYMZdkMLGcwjEcwpMoLX5uWk7mcQHCXh6k=
 github.com/Tusamarco/toml v0.3.1/go.mod h1:Q6HYrLTWNCzVXlbab9ajdRAx3eeWjDM4QlKJEuIXgUw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/DataObjects/Locker.go
+++ b/internal/DataObjects/Locker.go
@@ -113,7 +113,9 @@ func (locker *LockerImpl) CheckClusterLock() *ProxySQLNodeImpl {
 	// 1 get connection
 	// 2 get all we need from ProxySQL
 	// 3 put the lock if we can
-	global.SetPerformanceObj("Cluster lock", true, log.InfoLevel)
+	if global.Performance {
+		global.SetPerformanceObj("Cluster lock", true, log.InfoLevel)
+	}
 	proxySQLCluster := new(ProxySQLClusterImpl)
 	if !locker.MyServer.IsInitialized {
 		if !locker.MyServer.Init(locker.myConfig) {
@@ -130,21 +132,28 @@ func (locker *LockerImpl) CheckClusterLock() *ProxySQLNodeImpl {
 		if proxySQLCluster.GetProxySQLnodes(locker.MyServer) && len(proxySQLCluster.Nodes) > 0 {
 			if nodes, ok := locker.findLock(proxySQLCluster.Nodes); ok && nodes != nil {
 				if locker.PushSchedulerLock(nodes) {
-					global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
+					if global.Performance {
+						global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
+					}
 					return locker.MyServer
 				} else {
-					global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
+					if global.Performance {
+						global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
+					}
 					return nil
 				}
 			} else {
 				log.Info(fmt.Sprintf("Cannot put a lock on the cluster for this scheduler %s another node hold the lock and acting", locker.MyServer.Dns))
-				global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
+				if global.Performance {
+					global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
+				}
 				return nil
 			}
 		}
 	}
-
-	global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
+	if global.Performance {
+		global.SetPerformanceObj("Cluster lock", false, log.InfoLevel)
+	}
 	return locker.MyServer
 }
 

--- a/internal/DataObjects/proxySQLObjects.go
+++ b/internal/DataObjects/proxySQLObjects.go
@@ -93,9 +93,8 @@ func (cluster ProxySQLClusterImpl) GetProxySQLnodes(myNode *ProxySQLNodeImpl) bo
 
 		// Given Proxysql is NOT removing a non healthy node from proxySQL_cluster I must add a step here to check and eventually remove failing ProxySQL nodes
 		if newNode.GetConnection() {
-			if newNode.Dns != myNode.Dns {
 				newNode.CloseConnection()
-			}
+
 			cluster.Nodes[newNode.Dns] = *newNode
 		} else {
 			log.Error(fmt.Sprintf("ProxySQL Node %s is down or not reachable PLEASE REMOVE IT from the proxysql_servers table OR fix the issue", newNode.Dns))

--- a/internal/Global/help.go
+++ b/internal/Global/help.go
@@ -40,18 +40,16 @@ Parameters for the executable --configfile <file name> --configpath <full path> 
 
 Parameters in the config file:
 Global:
-	debug = true
-	logLevel = "debug"
+	logLevel = "info"
 	logTarget = "stdout" #stdout | file
 	logFile = "/Users/marcotusa/work/temp/pscheduler.log"
-	development = true
-	devInterval = 2000
+	daemonize = false
+	daemonInterval = 2000
 	performance = true
 	OS = "na"
-	debug : [false] will active some additional features to debug locally as more verbose logs
-	development : [false] Will allow the script to run in a loop without the need to be call by ProxySQL scheduler
-	devInterval : Define in ms the time for looping when in development mode
-	loglevel : [error] Define the log level to be used
+	daemonize : [false] Will allow the script to run in a loop without the need to be call by ProxySQL scheduler
+	daemonInterval : Define in ms the time for looping when in development mode
+	loglevel : [info] Define the log level to be used
 	logTarget : [stdout] Can be either a file or stdout
 	logFile : In case file for loging define the target
 	OS : for future use
@@ -65,7 +63,7 @@ ProxySQL
 Pxccluster
 	activeFailover : [1] Failover method
 	failBack : [false] If we should fail-back automatically or wait for manual intervention
-	checkTimeOut : [4000] This is one of the most important settings. When checking the Backend node (MySQL), it is possible that the node will not be able to answer in a consistent amount of time, due the different level of load. If this exceeds the Timeout, a warning will be print in the log, and the node will not be processed. Parsing the log it is possible to identify which is the best value for checkTimeOut to satisfy the need of speed and at the same time to give the nodes the time they need to answer.
+	checkTimeOut : [4000] This is one of the most important settings. When checking the Backend node (MySQL), it is possible that the node will not be able to answer in a consistent amount of time, due the different level of load. If this exceeds the Timeout, a warning will be printed in the log, and the node will not be processed. Parsing the log it is possible to identify which is the best value for checkTimeOut to satisfy the need of speed and at the same time to give the nodes the time they need to answer.
 	debug : [0] Some additional debug specific for the pxc cluster
 	mainSegment : [1] This is another very important value to set, it defines which is the MAIN segment for failover
 	sslClient : "client-cert.pem" In case of use of SSL for backend we need to be able to use the right credential
@@ -74,14 +72,17 @@ Pxccluster
 	sslCertificatePath : ["/full-path/ssl_test"] Full path for the SSL certificates
 	hgW : Writer HG
 	hgR : Reader HG
-	bckHgW : Backup HG in the 8XXX range (hgW + 8000)
-	bckHgR : Backup HG in the 8XXX range (hgR + 8000)
+    configHgRange =8000      : The starting value of the configuration groups (hgW + configHgRange) and (hgR + configHgRange) 
+	maintenanceHgRange =9000 : The starting value of the maintenance groups (hgW + maintenanceHgRange) and (hgR + maintenanceHgRange)
+	(Deprecated) bckHgW : Backup HG in the 8XXX range (hgW + 8000)
+	(Deprecated) bckHgR : Backup HG in the 8XXX range (hgR + 8000)
 	singlePrimary : [true] This is the recommended way, always use Galera in Single Primary to avoid write conflicts
 	maxNumWriters : [1] If SinglePrimary is false you can define how many nodes to have as Writers at the same time
 	writerIsAlsoReader : [1] Possible values 0 - 1. The default is 1, if you really want to exclude the writer from read set it to 0. When the cluster will lose its last reader, the writer will be elected as Reader, no matter what.
-	retryUp : [0] Number of retry the script should do before restoring a failed node
-	retryDown : [0] Number of retry the script should do to put DOWN a failing node
+	retryUp : [0] Number of retries the application should do before restoring a failed node
+	retryDown : [0] Number of retries the application should do to put DOWN a failing node
 	clusterId : 10 the ID for the cluster
+
 	Examples of configurations in ProxySQL
 	Simply pass max 2 arguments
 

--- a/mtr/proxysql/galera_3nodes.cnf
+++ b/mtr/proxysql/galera_3nodes.cnf
@@ -9,8 +9,8 @@ mysqlx=0
 
 # enforce read-committed characteristics across the cluster
 
-wsrep_causal_reads=ON
-wsrep_sync_wait = 15
+#wsrep_causal_reads=ON
+#wsrep_sync_wait = 15
 
 # Required for Galera
 innodb_autoinc_lock_mode=2

--- a/pxc_scheduler_handler.go
+++ b/pxc_scheduler_handler.go
@@ -30,15 +30,17 @@ import (
 	global "pxc_scheduler_handler/internal/Global"
 )
 
+var pxcSchedulerHandlerVersion = "1.3.1"
+
 /*
-Main function must contains only initial parameter, log system init and main object init
+Main function must contain only initial parameter, log system init and main object init
 */
 func main() {
 	//global setup of basic parameters
 	const (
 		Separator = string(os.PathSeparator)
 	)
-	pxcSchedulerHandlerVersion := "1.3.1"
+
 	var daemonLoopWait = 0
 	var daemonLoop = 0
 	//var lockId string //LockId is compose by clusterID_HG_W_HG_R
@@ -153,6 +155,11 @@ func main() {
 
 			if locker.CheckClusterLock() != nil {
 				//our node has the lock
+				locker.MyServer.CloseConnection()
+				if log.GetLevel() == log.DebugLevel {
+					log.Info("ProxySQL Cluster Connection close")
+				}
+
 				if !initProxySQLNode(proxysqlNode, config) {
 					locker.RemoveLockFile()
 					os.Exit(1)

--- a/pxc_scheduler_handler.go
+++ b/pxc_scheduler_handler.go
@@ -30,7 +30,7 @@ import (
 	global "pxc_scheduler_handler/internal/Global"
 )
 
-var pxcSchedulerHandlerVersion = "1.3.1"
+var pxcSchedulerHandlerVersion = "1.3.2"
 
 /*
 Main function must contain only initial parameter, log system init and main object init


### PR DESCRIPTION
Fixing:
- issue 47
- minor bug on performance reporting
- readme 

```
==============================================================================
                  TEST NAME                       RESULT  TIME (ms) COMMENT
------------------------------------------------------------------------------
[  1%] proxysql.reader_add1                      [ fail ]
[  1%] proxysql.reader_add1                      [ retry-pass ]  61049
[  1%] proxysql.reader_add1                      [ retry-pass ]  60958
[  3%] proxysql.reader_add1_notdef_conf_hg       [ pass ]  60751
[  5%] proxysql.reader_add2                      [ pass ]  60760
[  7%] proxysql.reader_add3                      [ pass ]  60943
[  9%] proxysql.reader_add4                      [ pass ]  60867
[ 11%] proxysql.reader_desync1                   [ pass ]  61501
[ 13%] proxysql.reader_desync2                   [ pass ]  61158
[ 15%] proxysql.reader_desync3                   [ pass ]  60741
[ 17%] proxysql.reader_desync4                   [ pass ]  61140
[ 19%] proxysql.reader_kill1                     [ pass ]  247082
[ 21%] proxysql.reader_kill2                     [ pass ]  243676
[ 23%] proxysql.reader_kill3                     [ pass ]  244022
[ 25%] proxysql.reader_kill4                     [ pass ]  242568
[ 26%] proxysql.reader_reject_queries1           [ pass ]  61096
[ 28%] proxysql.reader_reject_queries2           [ pass ]  61118
[ 30%] proxysql.reader_reject_queries3           [ pass ]  61558
[ 32%] proxysql.reader_reject_queries4           [ pass ]  60932
[ 34%] proxysql.reader_to_maintenance1           [ pass ]  61590
[ 36%] proxysql.reader_to_maintenance2           [ pass ]  61130
[ 38%] proxysql.reader_to_maintenance3           [ pass ]  60903
[ 40%] proxysql.reader_to_maintenance4           [ pass ]  60757
[ 42%] proxysql.reader_to_readonly1              [ pass ]  60938
[ 44%] proxysql.reader_to_readonly2              [ pass ]  61125
[ 46%] proxysql.reader_to_readonly3              [ pass ]  60775
[ 48%] proxysql.reader_to_readonly4              [ pass ]  61840
[ 50%] proxysql.writer_add1                      [ pass ]  60676
[ 51%] proxysql.writer_add2                      [ pass ]  60600
[ 53%] proxysql.writer_add3                      [ pass ]  60860
[ 55%] proxysql.writer_add4                      [ pass ]  60720
[ 57%] proxysql.writer_desync1                   [ pass ]  60875
[ 59%] proxysql.writer_desync2                   [ pass ]  60921
[ 61%] proxysql.writer_desync3                   [ pass ]  61638
[ 63%] proxysql.writer_desync4                   [ pass ]  61527
[ 65%] proxysql.writer_kill1                     [ pass ]  245125
[ 67%] proxysql.writer_kill1_persist             [ pass ]  244887
[ 69%] proxysql.writer_kill2                     [ pass ]  242989
[ 71%] proxysql.writer_kill2b                    [ pass ]  244264
[ 73%] proxysql.writer_kill3                     [ pass ]  243194
[ 75%] proxysql.writer_kill4                     [ pass ]  244885
[ 76%] proxysql.writer_reject_queries1           [ pass ]  61951
[ 78%] proxysql.writer_reject_queries2           [ pass ]  61296
[ 80%] proxysql.writer_reject_queries3           [ pass ]  61187
[ 82%] proxysql.writer_reject_queries4           [ pass ]  61093
[ 84%] proxysql.writer_to_maintenance1           [ pass ]  60886
[ 86%] proxysql.writer_to_maintenance2           [ pass ]  60938
[ 88%] proxysql.writer_to_maintenance3           [ pass ]  60839
[ 90%] proxysql.writer_to_maintenance4           [ pass ]  60889
[ 92%] proxysql.writer_to_readonly1              [ pass ]  60845
[ 94%] proxysql.writer_to_readonly2              [ pass ]  61226
[ 96%] proxysql.writer_to_readonly3              [ pass ]  61263
[ 98%] proxysql.writer_to_readonly4              [ pass ]  61494
[100%] shutdown_report                           [ pass ]       
------------------------------------------------------------------------------
The servers were restarted 1 times
The servers were reinitialized 0 times
Spent 5008.046 of 5341 seconds executing testcases
Uinit tests

tusa@apptest pxc_scheduler_handler]$ go  test ./... -v |grep -v \?|grep -v time
=== RUN   TestLockerImpl_findLock
=== RUN   TestLockerImpl_findLock/Locker_base_disable
=== RUN   TestLockerImpl_findLock/Locker_expire_lock_on_other_node
=== RUN   TestLockerImpl_findLock/Locker_expire_lock_on_other_node_no_previous_lock_on_node
=== RUN   TestLockerImpl_findLock/Locker_lock_is_still_good_on_other_node
=== RUN   TestLockerImpl_findLock/Locker_expire_lock_on_my_node
--- PASS: TestLockerImpl_findLock (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_base_disable (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_expire_lock_on_other_node (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_expire_lock_on_other_node_no_previous_lock_on_node (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_lock_is_still_good_on_other_node (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_expire_lock_on_my_node (0.00s)
=== RUN   TestDataClusterImpl_checkWsrepDesync
=== RUN   TestDataClusterImpl_checkWsrepDesync/No_change_W
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_in_W_but_only_1
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_in_W_and_2_in_HG
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_in_R_and_1_in_HG
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_in_R_and_2_in_HG
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_2_HG_R_and_Local_Replica_queue_>_MaxReplicationLag
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_2_HG_R_and_Local_Replica_queue_<_MaxReplicationLag
--- PASS: TestDataClusterImpl_checkWsrepDesync (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/No_change_W (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_in_W_but_only_1 (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_in_W_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_in_R_and_1_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_in_R_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_2_HG_R_and_Local_Replica_queue_>_MaxReplicationLag (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_2_HG_R_and_Local_Replica_queue_<_MaxReplicationLag (0.00s)
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/No_change_W
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_W_but_only_1
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_W_and_2_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_R_and_1_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_R_and_2_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_W_but_only_1
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_W_and_2_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_R_and_1_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_R_and_2_in_HG
--- PASS: TestDataClusterImpl_checkAnyNotReadyStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/No_change_W (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_W_but_only_1 (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_W_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_R_and_1_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_R_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_W_but_only_1 (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_W_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_R_and_1_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_R_and_2_in_HG (0.00s)
=== RUN   TestDataClusterImpl_checkNotPrimary
=== RUN   TestDataClusterImpl_checkNotPrimary/No_WsrepClusterStatus_change_
=== RUN   TestDataClusterImpl_checkNotPrimary/Change_WsrepClusterStatus_=_NOT_Primary_in_W_
--- PASS: TestDataClusterImpl_checkNotPrimary (0.00s)
    --- PASS: TestDataClusterImpl_checkNotPrimary/No_WsrepClusterStatus_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkNotPrimary/Change_WsrepClusterStatus_=_NOT_Primary_in_W_ (0.00s)
=== RUN   TestDataClusterImpl_checkRejectQueries
=== RUN   TestDataClusterImpl_checkRejectQueries/No_WsrepRejectqueries_change_
=== RUN   TestDataClusterImpl_checkRejectQueries/Change_WsrepRejectqueries_=_ALL_in_W_
=== RUN   TestDataClusterImpl_checkRejectQueries/Change_WsrepRejectqueries_=_ALL_in_W_#01
--- PASS: TestDataClusterImpl_checkRejectQueries (0.00s)
    --- PASS: TestDataClusterImpl_checkRejectQueries/No_WsrepRejectqueries_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkRejectQueries/Change_WsrepRejectqueries_=_ALL_in_W_ (0.00s)
    --- PASS: TestDataClusterImpl_checkRejectQueries/Change_WsrepRejectqueries_=_ALL_in_W_#01 (0.00s)
=== RUN   TestDataClusterImpl_checkDonorReject
=== RUN   TestDataClusterImpl_checkDonorReject/No_WsrepDonorrejectqueries_change_
=== RUN   TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_W_HG_size_=_1
=== RUN   TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_W_HG_size_=_2
=== RUN   TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_R_and_1_in_HG
=== RUN   TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_R_and_2_in_HG
--- PASS: TestDataClusterImpl_checkDonorReject (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/No_WsrepDonorrejectqueries_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_W_HG_size_=_1 (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_W_HG_size_=_2 (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_R_and_1_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_R_and_2_in_HG (0.00s)
=== RUN   TestDataClusterImpl_checkPxcMaint
=== RUN   TestDataClusterImpl_checkPxcMaint/No_PxcMaintMode_change_
=== RUN   TestDataClusterImpl_checkPxcMaint/Change_PxcMaintMode_=_Maintenance
=== RUN   TestDataClusterImpl_checkPxcMaint/Change_PxcMaintMode_=_Maintenance_and_OFFLINE_SOFT
--- PASS: TestDataClusterImpl_checkPxcMaint (0.00s)
    --- PASS: TestDataClusterImpl_checkPxcMaint/No_PxcMaintMode_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkPxcMaint/Change_PxcMaintMode_=_Maintenance (0.00s)
    --- PASS: TestDataClusterImpl_checkPxcMaint/Change_PxcMaintMode_=_Maintenance_and_OFFLINE_SOFT (0.00s)
=== RUN   TestDataClusterImpl_checkReadOnly
=== RUN   TestDataClusterImpl_checkReadOnly/No_ReadOnly_change_
=== RUN   TestDataClusterImpl_checkReadOnly/Change_ReadOnly_=_On_1_writer_
=== RUN   TestDataClusterImpl_checkReadOnly/Change_ReadOnly_=_On_2_writers_
=== RUN   TestDataClusterImpl_checkReadOnly/CChange_ReadOnly_=_On_2_readers_
--- PASS: TestDataClusterImpl_checkReadOnly (0.00s)
    --- PASS: TestDataClusterImpl_checkReadOnly/No_ReadOnly_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkReadOnly/Change_ReadOnly_=_On_1_writer_ (0.00s)
    --- PASS: TestDataClusterImpl_checkReadOnly/Change_ReadOnly_=_On_2_writers_ (0.00s)
    --- PASS: TestDataClusterImpl_checkReadOnly/CChange_ReadOnly_=_On_2_readers_ (0.00s)
=== RUN   TestDataClusterImpl_checkBackOffLine
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_no_changes_
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_WsrepStatus
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_ProxyStatus
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_WsrepClusterStatus
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_PxcMaintMode
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_PxcMaintMode#01
--- PASS: TestDataClusterImpl_checkBackOffLine (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_no_changes_ (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_WsrepStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_ProxyStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_WsrepClusterStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_PxcMaintMode (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_PxcMaintMode#01 (0.00s)
=== RUN   TestDataClusterImpl_checkBackDesyncButUnderReplicaLag
=== RUN   TestDataClusterImpl_checkBackDesyncButUnderReplicaLag/Back_from_OFFLINE_SOFT_no_changes_
=== RUN   TestDataClusterImpl_checkBackDesyncButUnderReplicaLag/Back_from_OFFLINE_SOFT__when_Local_Replica_queue_<_of_50%_MaxReplicationLag
--- PASS: TestDataClusterImpl_checkBackDesyncButUnderReplicaLag (0.00s)
    --- PASS: TestDataClusterImpl_checkBackDesyncButUnderReplicaLag/Back_from_OFFLINE_SOFT_no_changes_ (0.00s)
    --- PASS: TestDataClusterImpl_checkBackDesyncButUnderReplicaLag/Back_from_OFFLINE_SOFT__when_Local_Replica_queue_<_of_50%_MaxReplicationLag (0.00s)
=== RUN   TestDataClusterImpl_checkBackNew
=== RUN   TestDataClusterImpl_checkBackNew/Backup_Node_has_lower_weight_No_action_
=== RUN   TestDataClusterImpl_checkBackNew/Back_online_Node_is_new_no_changes_
--- PASS: TestDataClusterImpl_checkBackNew (0.00s)
    --- PASS: TestDataClusterImpl_checkBackNew/Backup_Node_has_lower_weight_No_action_ (0.00s)
    --- PASS: TestDataClusterImpl_checkBackNew/Back_online_Node_is_new_no_changes_ (0.00s)
=== RUN   TestDataClusterImpl_checkBackPrimary
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_no_changes
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepStatus
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_HostgroupId
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepClusterStatus
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_PxcMaintMode
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepRejectqueries
--- PASS: TestDataClusterImpl_checkBackPrimary (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_HostgroupId (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepClusterStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_PxcMaintMode (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepRejectqueries (0.00s)
=== RUN   TestDataClusterImpl_cleanWriters
=== RUN   TestDataClusterImpl_cleanWriters/Check_evaluateWriters_-_cleanWriters_no_changes
=== RUN   TestDataClusterImpl_cleanWriters/Check_evaluateWriters_-_cleanWriters_One_node_is_offline
--- PASS: TestDataClusterImpl_cleanWriters (0.00s)
    --- PASS: TestDataClusterImpl_cleanWriters/Check_evaluateWriters_-_cleanWriters_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_cleanWriters/Check_evaluateWriters_-_cleanWriters_One_node_is_offline (0.00s)
=== RUN   TestDataClusterImpl_identifyPrimaryBackupNode
=== RUN   TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_no_changes
=== RUN   TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_Only_for_Writer
=== RUN   TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_Only_for_Writer#01
--- PASS: TestDataClusterImpl_identifyPrimaryBackupNode (0.00s)
    --- PASS: TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_Only_for_Writer (0.00s)
    --- PASS: TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_Only_for_Writer#01 (0.00s)
=== RUN   TestDataClusterImpl_processUpAndDownReaders
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_no_changes
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_DOWN_HG_CHANGE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_DOWN_OFFLINE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_TO_MAINTENANCE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_SWAP_READER_TO_WRITER
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_UP_OFFLINE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_UP_HG_CHANGE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_INSERT_READ
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_SWAP_WRITER_TO_READER
--- PASS: TestDataClusterImpl_processUpAndDownReaders (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_DOWN_HG_CHANGE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_DOWN_OFFLINE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_TO_MAINTENANCE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_SWAP_READER_TO_WRITER (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_UP_OFFLINE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_UP_HG_CHANGE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_INSERT_READ (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_SWAP_WRITER_TO_READER (0.00s)
=== RUN   TestDataClusterImpl_processWriterIsAlsoReader
=== RUN   TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_no_changes
=== RUN   TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_WriterIsAlso_reader_=_0_and_2_readers_
=== RUN   TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_WriterIsAlso_reader_=_0_and_1_readers_
--- PASS: TestDataClusterImpl_processWriterIsAlsoReader (0.00s)
    --- PASS: TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_WriterIsAlso_reader_=_0_and_2_readers_ (0.00s)
    --- PASS: TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_WriterIsAlso_reader_=_0_and_1_readers_ (0.00s)
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemove
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_lower_weight_No_action_
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_Higher_weigh_so_another_node_must_go_
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_mid_weigh_so_another_node_must_go_
--- PASS: TestDataClusterImpl_identifyLowerNodeToRemove (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_lower_weight_No_action_ (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_Higher_weigh_so_another_node_must_go_ (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_mid_weigh_so_another_node_must_go_ (0.00s)
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_lower_weight_No_action_
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_Higher_weigh_so_another_node_must_go_
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_mid_weigh_so_no_action_as_well_
--- PASS: TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_lower_weight_No_action_ (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_Higher_weigh_so_another_node_must_go_ (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_mid_weigh_so_no_action_as_well_ (0.00s)
PASS
```