### PR TITLE
Issue 50

### DIFF
--- a/internal/DataObjects/dataObjects.go
+++ b/internal/DataObjects/dataObjects.go
@@ -371,7 +371,7 @@ func (cluster *DataClusterImpl) getNodesInfo() bool {
 	}
 	end := time.Now().UnixNano()
 	timems := (end - start) / 1000000
-	log.Debug("time taken :", timems, " checkTimeOut : ", cluster.CheckTimeout)
+	log.Debug("time taken : ", timems, " ms; checkTimeOut : ", cluster.CheckTimeout, " ms")
 	if int(timems) > cluster.CheckTimeout {
 		log.Warning("CheckTimeout exceeded try to increase it above the execution time : ", timems)
 		if waitingGroup.ReportCounter() > 0 {

--- a/internal/Global/help.go
+++ b/internal/Global/help.go
@@ -105,18 +105,18 @@ As Hostgroup:
 We will need to :
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.22',100,3306,1000,2000,'Preferred writer');
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.23',100,3306,999,2000,'Second preferred ');
-	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.233',100,3306,998,2000,'Las chance');
-	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.22',101,3306,998,2000,'last reader');
-	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.23',101,3306,1000,2000,'reader1');    
-	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.233',101,3306,1000,2000,'reader2');        
+	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.233',100,3306,998,2000,'Last chance');
+	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.22',101,3306,998,2000,'Last reader');
+	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.23',101,3306,1000,2000,'Reader1');    
+	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.233',101,3306,1000,2000,'Reader2');        
 	
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.22',8100,3306,1000,2000,'Failover server preferred');
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.23',8100,3306,999,2000,'Second preferred');    
-	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.233',8100,3306,998,2000,'Thirdh and last in the list');      
+	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.233',8100,3306,998,2000,'Third and last in the list');      
 	
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.22',8101,3306,998,2000,'Failover server preferred');
 	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.23',8101,3306,999,2000,'Second preferred');    
-	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.233',8101,3306,1000,2000,'Thirdh and last in the list');      
+	INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,comment) VALUES ('192.168.4.233',8101,3306,1000,2000,'Third and last in the list');      
 
 	LOAD MYSQL SERVERS TO RUNTIME; SAVE MYSQL SERVERS TO DISK;
 `

--- a/internal/Global/utils.go
+++ b/internal/Global/utils.go
@@ -367,7 +367,7 @@ func ReportPerformance() {
 			if perfObj.LogLevel <= log.GetLevel() {
 				originalLogLevel := log.GetLevel()
 				log.SetLevel(log.InfoLevel)
-				log.Info("Phase: ", perfObj.Name, " = ", value, " us ", strconv.FormatInt((time[1]-time[0])/1000000, 10), " ms")
+				log.Info("Phase: ", perfObj.Name, " = ", value, " ns ", strconv.FormatInt((time[1]-time[0])/1000000, 10), " ms")
 				log.SetLevel(originalLogLevel)
 			}
 		}

--- a/internal/Global/utils.go
+++ b/internal/Global/utils.go
@@ -32,6 +32,7 @@ import (
 )
 
 type MyWaitGroup struct {
+	sync.Mutex
 	sync.WaitGroup
 	count int
 }
@@ -54,15 +55,21 @@ func (wg *MyWaitGroup) WaitTimeout(timeout time.Duration) bool {
 }
 
 func (wg *MyWaitGroup) IncreaseCounter() {
+	wg.Lock()
+	defer wg.Unlock()
 	wg.count++
 }
 func (wg *MyWaitGroup) DecreaseCounter() {
 	if wg.count > 0 {
+		wg.Lock()
+		defer wg.Unlock()
 		wg.count--
 	}
 }
 
 func (wg *MyWaitGroup) ReportCounter() int {
+	wg.Lock()
+	defer wg.Unlock()
 	return wg.count
 }
 

--- a/mtr/proxysql/t/pxc_node_kill.inc
+++ b/mtr/proxysql/t/pxc_node_kill.inc
@@ -5,7 +5,7 @@
 #
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1:          backup reader / backup wrtier
+#  node_1:          backup reader / backup writer
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/reader_add.inc
+++ b/mtr/proxysql/t/reader_add.inc
@@ -1,7 +1,7 @@
 # This is common scenario for 1 writer, 2 reades, 2 backup writers, 1 backup reader
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1: reader/backup wrtier weight 1000
+#  node_1: reader/backup writer weight 1000
 #  node_2: writer
 #  node_3: reader/backup writer weight 999/backup reader
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/reader_add1.test
+++ b/mtr/proxysql/t/reader_add1.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1: reader/backup wrtier weight 1000
+#  node_1: reader/backup writer weight 1000
 #  node_2: writer
 #  node_3: reader/backup writer weight 999/backup reader
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/reader_add1_notdef_conf_hg.test
+++ b/mtr/proxysql/t/reader_add1_notdef_conf_hg.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1: reader/backup wrtier weight 1000
+#  node_1: reader/backup writer weight 1000
 #  node_2: writer
 #  node_3: reader/backup writer weight 999/backup reader
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/reader_add2.test
+++ b/mtr/proxysql/t/reader_add2.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1: reader/backup wrtier weight 1000
+#  node_1: reader/backup writer weight 1000
 #  node_2: writer
 #  node_3: reader/backup writer weight 999/backup reader
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/reader_add3.test
+++ b/mtr/proxysql/t/reader_add3.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1: reader/backup wrtier weight 1000
+#  node_1: reader/backup writer weight 1000
 #  node_2: writer
 #  node_3: reader/backup writer weight 999/backup reader
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/reader_add4.test
+++ b/mtr/proxysql/t/reader_add4.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1: reader/backup wrtier weight 1000
+#  node_1: reader/backup writer weight 1000
 #  node_2: writer
 #  node_3: reader/backup writer weight 999/backup reader
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/reader_add_notdef_conf_hg.inc
+++ b/mtr/proxysql/t/reader_add_notdef_conf_hg.inc
@@ -1,7 +1,7 @@
 # This is common scenario for 1 writer, 2 reades, 2 backup writers, 1 backup reader
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1: reader/backup wrtier weight 1000
+#  node_1: reader/backup writer weight 1000
 #  node_2: writer
 #  node_3: reader/backup writer weight 999/backup reader
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/reader_kill1.test
+++ b/mtr/proxysql/t/reader_kill1.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1:          backup reader / backup wrtier
+#  node_1:          backup reader / backup writer
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/reader_kill2.test
+++ b/mtr/proxysql/t/reader_kill2.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1:          backup reader / backup wrtier
+#  node_1:          backup reader / backup writer
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/reader_kill3.test
+++ b/mtr/proxysql/t/reader_kill3.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1: reader writer / backup reader / backup wrtier
+#  node_1: reader writer / backup reader / backup writer
 #  node_2: reader        / backup reader / backup writer
 #  node_3:        writer / backup reader / backup writer
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/reader_kill4.test
+++ b/mtr/proxysql/t/reader_kill4.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1:          backup reader / backup wrtier
+#  node_1:          backup reader / backup writer
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/writer_kill1.test
+++ b/mtr/proxysql/t/writer_kill1.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1:          backup reader / backup wrtier
+#  node_1:          backup reader / backup writer
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/writer_kill1_persist.test
+++ b/mtr/proxysql/t/writer_kill1_persist.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1:          backup reader / backup wrtier
+#  node_1:          backup reader / backup writer
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/writer_kill2.test
+++ b/mtr/proxysql/t/writer_kill2.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1:          backup reader / backup wrtier
+#  node_1:          backup reader / backup writer
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/writer_kill2b.test
+++ b/mtr/proxysql/t/writer_kill2b.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1:          backup reader / backup wrtier
+#  node_1:          backup reader / backup writer
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/writer_kill3.test
+++ b/mtr/proxysql/t/writer_kill3.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1: reader writer / backup reader / backup wrtier
+#  node_1: reader writer / backup reader / backup writer
 #  node_2: reader        / backup reader / backup writer
 #  node_3:        writer / backup reader / backup writer
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config

--- a/mtr/proxysql/t/writer_kill4.test
+++ b/mtr/proxysql/t/writer_kill4.test
@@ -1,6 +1,6 @@
 # 1. Setup 3 node PXC cluster
 # 2. Setup ProxySQL 
-#  node_1:          backup reader / backup wrtier
+#  node_1:          backup reader / backup writer
 #  node_2: reader / backup reader / backup writer
 #  node_3: writer / backup reader / backup writer
 # 3. Setup ProxySQL scheduler with config passed in $pxc_scheduler_handler_config


### PR DESCRIPTION
Fixing a problem as describe in [issue 50](https://github.com/percona/pxc_scheduler_handler/issues/50)
The issue was that under high contention the object keeping track the running threads was having issue in decrementing correctly the number of active threads.
The adoption of a mutex on the methods: 
- increment
- decrement
- report

Fixed the issue. 
The effects of the issue was that also if all nodes were correctly reported back, the scheduler was exiting the checking loop only on timeout. That was not compromising the checks but was causing a delay in action. 
Other fix are spelling corrections as for PR-51 from @venkatesh-prasad-v 