### PR TITLE
Fix auto failover

### DIFF
--- a/pxc_scheduler_handler.go
+++ b/pxc_scheduler_handler.go
@@ -30,7 +30,7 @@ import (
 	global "pxc_scheduler_handler/internal/Global"
 )
 
-var pxcSchedulerHandlerVersion = "1.3.3"
+var pxcSchedulerHandlerVersion = "1.3.4"
 
 /*
 Main function must contain only initial parameter, log system init and main object init


### PR DESCRIPTION
Fixing a bug in the auto-failover. Always happening despite setting it to 0.

```
==============================================================================
                  TEST NAME                       RESULT  TIME (ms) COMMENT
------------------------------------------------------------------------------
[  1%] proxysql.reader_add1                      [ fail ]
[  1%] proxysql.reader_add1                      [ retry-pass ]  61049
[  1%] proxysql.reader_add1                      [ retry-pass ]  60958
[  3%] proxysql.reader_add1_notdef_conf_hg       [ pass ]  60751
[  5%] proxysql.reader_add2                      [ pass ]  60760
[  7%] proxysql.reader_add3                      [ pass ]  60943
[  9%] proxysql.reader_add4                      [ pass ]  60867
[ 11%] proxysql.reader_desync1                   [ pass ]  61501
[ 13%] proxysql.reader_desync2                   [ pass ]  61158
[ 15%] proxysql.reader_desync3                   [ pass ]  60741
[ 17%] proxysql.reader_desync4                   [ pass ]  61140
[ 19%] proxysql.reader_kill1                     [ pass ]  247082
[ 21%] proxysql.reader_kill2                     [ pass ]  243676
[ 23%] proxysql.reader_kill3                     [ pass ]  244022
[ 25%] proxysql.reader_kill4                     [ pass ]  242568
[ 26%] proxysql.reader_reject_queries1           [ pass ]  61096
[ 28%] proxysql.reader_reject_queries2           [ pass ]  61118
[ 30%] proxysql.reader_reject_queries3           [ pass ]  61558
[ 32%] proxysql.reader_reject_queries4           [ pass ]  60932
[ 34%] proxysql.reader_to_maintenance1           [ pass ]  61590
[ 36%] proxysql.reader_to_maintenance2           [ pass ]  61130
[ 38%] proxysql.reader_to_maintenance3           [ pass ]  60903
[ 40%] proxysql.reader_to_maintenance4           [ pass ]  60757
[ 42%] proxysql.reader_to_readonly1              [ pass ]  60938
[ 44%] proxysql.reader_to_readonly2              [ pass ]  61125
[ 46%] proxysql.reader_to_readonly3              [ pass ]  60775
[ 48%] proxysql.reader_to_readonly4              [ pass ]  61840
[ 50%] proxysql.writer_add1                      [ pass ]  60676
[ 51%] proxysql.writer_add2                      [ pass ]  60600
[ 53%] proxysql.writer_add3                      [ pass ]  60860
[ 55%] proxysql.writer_add4                      [ pass ]  60720
[ 57%] proxysql.writer_desync1                   [ pass ]  60875
[ 59%] proxysql.writer_desync2                   [ pass ]  60921
[ 61%] proxysql.writer_desync3                   [ pass ]  61638
[ 63%] proxysql.writer_desync4                   [ pass ]  61527
[ 65%] proxysql.writer_kill1                     [ pass ]  245125
[ 67%] proxysql.writer_kill1_persist             [ pass ]  244887
[ 69%] proxysql.writer_kill2                     [ pass ]  242989
[ 71%] proxysql.writer_kill2b                    [ pass ]  244264
[ 73%] proxysql.writer_kill3                     [ pass ]  243194
[ 75%] proxysql.writer_kill4                     [ pass ]  244885
[ 76%] proxysql.writer_reject_queries1           [ pass ]  61951
[ 78%] proxysql.writer_reject_queries2           [ pass ]  61296
[ 80%] proxysql.writer_reject_queries3           [ pass ]  61187
[ 82%] proxysql.writer_reject_queries4           [ pass ]  61093
[ 84%] proxysql.writer_to_maintenance1           [ pass ]  60886
[ 86%] proxysql.writer_to_maintenance2           [ pass ]  60938
[ 88%] proxysql.writer_to_maintenance3           [ pass ]  60839
[ 90%] proxysql.writer_to_maintenance4           [ pass ]  60889
[ 92%] proxysql.writer_to_readonly1              [ pass ]  60845
[ 94%] proxysql.writer_to_readonly2              [ pass ]  61226
[ 96%] proxysql.writer_to_readonly3              [ pass ]  61263
[ 98%] proxysql.writer_to_readonly4              [ pass ]  61494
[100%] shutdown_report                           [ pass ]       
------------------------------------------------------------------------------
The servers were restarted 1 times
The servers were reinitialized 0 times
Spent 5008.046 of 5341 seconds executing testcases
Uinit tests

tusa@apptest pxc_scheduler_handler]$ go  test ./... -v |grep -v \?|grep -v time
=== RUN   TestLockerImpl_findLock
=== RUN   TestLockerImpl_findLock/Locker_base_disable
=== RUN   TestLockerImpl_findLock/Locker_expire_lock_on_other_node
=== RUN   TestLockerImpl_findLock/Locker_expire_lock_on_other_node_no_previous_lock_on_node
=== RUN   TestLockerImpl_findLock/Locker_lock_is_still_good_on_other_node
=== RUN   TestLockerImpl_findLock/Locker_expire_lock_on_my_node
--- PASS: TestLockerImpl_findLock (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_base_disable (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_expire_lock_on_other_node (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_expire_lock_on_other_node_no_previous_lock_on_node (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_lock_is_still_good_on_other_node (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_expire_lock_on_my_node (0.00s)
=== RUN   TestDataClusterImpl_checkWsrepDesync
=== RUN   TestDataClusterImpl_checkWsrepDesync/No_change_W
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_in_W_but_only_1
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_in_W_and_2_in_HG
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_in_R_and_1_in_HG
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_in_R_and_2_in_HG
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_2_HG_R_and_Local_Replica_queue_>_MaxReplicationLag
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_2_HG_R_and_Local_Replica_queue_<_MaxReplicationLag
--- PASS: TestDataClusterImpl_checkWsrepDesync (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/No_change_W (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_in_W_but_only_1 (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_in_W_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_in_R_and_1_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_in_R_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_2_HG_R_and_Local_Replica_queue_>_MaxReplicationLag (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_2_HG_R_and_Local_Replica_queue_<_MaxReplicationLag (0.00s)
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/No_change_W
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_W_but_only_1
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_W_and_2_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_R_and_1_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_R_and_2_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_W_but_only_1
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_W_and_2_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_R_and_1_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_R_and_2_in_HG
--- PASS: TestDataClusterImpl_checkAnyNotReadyStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/No_change_W (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_W_but_only_1 (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_W_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_R_and_1_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_R_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_W_but_only_1 (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_W_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_R_and_1_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_R_and_2_in_HG (0.00s)
=== RUN   TestDataClusterImpl_checkNotPrimary
=== RUN   TestDataClusterImpl_checkNotPrimary/No_WsrepClusterStatus_change_
=== RUN   TestDataClusterImpl_checkNotPrimary/Change_WsrepClusterStatus_=_NOT_Primary_in_W_
--- PASS: TestDataClusterImpl_checkNotPrimary (0.00s)
    --- PASS: TestDataClusterImpl_checkNotPrimary/No_WsrepClusterStatus_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkNotPrimary/Change_WsrepClusterStatus_=_NOT_Primary_in_W_ (0.00s)
=== RUN   TestDataClusterImpl_checkRejectQueries
=== RUN   TestDataClusterImpl_checkRejectQueries/No_WsrepRejectqueries_change_
=== RUN   TestDataClusterImpl_checkRejectQueries/Change_WsrepRejectqueries_=_ALL_in_W_
=== RUN   TestDataClusterImpl_checkRejectQueries/Change_WsrepRejectqueries_=_ALL_in_W_#01
--- PASS: TestDataClusterImpl_checkRejectQueries (0.00s)
    --- PASS: TestDataClusterImpl_checkRejectQueries/No_WsrepRejectqueries_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkRejectQueries/Change_WsrepRejectqueries_=_ALL_in_W_ (0.00s)
    --- PASS: TestDataClusterImpl_checkRejectQueries/Change_WsrepRejectqueries_=_ALL_in_W_#01 (0.00s)
=== RUN   TestDataClusterImpl_checkDonorReject
=== RUN   TestDataClusterImpl_checkDonorReject/No_WsrepDonorrejectqueries_change_
=== RUN   TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_W_HG_size_=_1
=== RUN   TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_W_HG_size_=_2
=== RUN   TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_R_and_1_in_HG
=== RUN   TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_R_and_2_in_HG
--- PASS: TestDataClusterImpl_checkDonorReject (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/No_WsrepDonorrejectqueries_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_W_HG_size_=_1 (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_W_HG_size_=_2 (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_R_and_1_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_R_and_2_in_HG (0.00s)
=== RUN   TestDataClusterImpl_checkPxcMaint
=== RUN   TestDataClusterImpl_checkPxcMaint/No_PxcMaintMode_change_
=== RUN   TestDataClusterImpl_checkPxcMaint/Change_PxcMaintMode_=_Maintenance
=== RUN   TestDataClusterImpl_checkPxcMaint/Change_PxcMaintMode_=_Maintenance_and_OFFLINE_SOFT
--- PASS: TestDataClusterImpl_checkPxcMaint (0.00s)
    --- PASS: TestDataClusterImpl_checkPxcMaint/No_PxcMaintMode_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkPxcMaint/Change_PxcMaintMode_=_Maintenance (0.00s)
    --- PASS: TestDataClusterImpl_checkPxcMaint/Change_PxcMaintMode_=_Maintenance_and_OFFLINE_SOFT (0.00s)
=== RUN   TestDataClusterImpl_checkReadOnly
=== RUN   TestDataClusterImpl_checkReadOnly/No_ReadOnly_change_
=== RUN   TestDataClusterImpl_checkReadOnly/Change_ReadOnly_=_On_1_writer_
=== RUN   TestDataClusterImpl_checkReadOnly/Change_ReadOnly_=_On_2_writers_
=== RUN   TestDataClusterImpl_checkReadOnly/CChange_ReadOnly_=_On_2_readers_
--- PASS: TestDataClusterImpl_checkReadOnly (0.00s)
    --- PASS: TestDataClusterImpl_checkReadOnly/No_ReadOnly_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkReadOnly/Change_ReadOnly_=_On_1_writer_ (0.00s)
    --- PASS: TestDataClusterImpl_checkReadOnly/Change_ReadOnly_=_On_2_writers_ (0.00s)
    --- PASS: TestDataClusterImpl_checkReadOnly/CChange_ReadOnly_=_On_2_readers_ (0.00s)
=== RUN   TestDataClusterImpl_checkBackOffLine
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_no_changes_
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_WsrepStatus
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_ProxyStatus
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_WsrepClusterStatus
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_PxcMaintMode
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_PxcMaintMode#01
--- PASS: TestDataClusterImpl_checkBackOffLine (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_no_changes_ (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_WsrepStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_ProxyStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_WsrepClusterStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_PxcMaintMode (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_PxcMaintMode#01 (0.00s)
=== RUN   TestDataClusterImpl_checkBackDesyncButUnderReplicaLag
=== RUN   TestDataClusterImpl_checkBackDesyncButUnderReplicaLag/Back_from_OFFLINE_SOFT_no_changes_
=== RUN   TestDataClusterImpl_checkBackDesyncButUnderReplicaLag/Back_from_OFFLINE_SOFT__when_Local_Replica_queue_<_of_50%_MaxReplicationLag
--- PASS: TestDataClusterImpl_checkBackDesyncButUnderReplicaLag (0.00s)
    --- PASS: TestDataClusterImpl_checkBackDesyncButUnderReplicaLag/Back_from_OFFLINE_SOFT_no_changes_ (0.00s)
    --- PASS: TestDataClusterImpl_checkBackDesyncButUnderReplicaLag/Back_from_OFFLINE_SOFT__when_Local_Replica_queue_<_of_50%_MaxReplicationLag (0.00s)
=== RUN   TestDataClusterImpl_checkBackNew
=== RUN   TestDataClusterImpl_checkBackNew/Backup_Node_has_lower_weight_No_action_
=== RUN   TestDataClusterImpl_checkBackNew/Back_online_Node_is_new_no_changes_
--- PASS: TestDataClusterImpl_checkBackNew (0.00s)
    --- PASS: TestDataClusterImpl_checkBackNew/Backup_Node_has_lower_weight_No_action_ (0.00s)
    --- PASS: TestDataClusterImpl_checkBackNew/Back_online_Node_is_new_no_changes_ (0.00s)
=== RUN   TestDataClusterImpl_checkBackPrimary
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_no_changes
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepStatus
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_HostgroupId
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepClusterStatus
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_PxcMaintMode
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepRejectqueries
--- PASS: TestDataClusterImpl_checkBackPrimary (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_HostgroupId (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepClusterStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_PxcMaintMode (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepRejectqueries (0.00s)
=== RUN   TestDataClusterImpl_cleanWriters
=== RUN   TestDataClusterImpl_cleanWriters/Check_evaluateWriters_-_cleanWriters_no_changes
=== RUN   TestDataClusterImpl_cleanWriters/Check_evaluateWriters_-_cleanWriters_One_node_is_offline
--- PASS: TestDataClusterImpl_cleanWriters (0.00s)
    --- PASS: TestDataClusterImpl_cleanWriters/Check_evaluateWriters_-_cleanWriters_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_cleanWriters/Check_evaluateWriters_-_cleanWriters_One_node_is_offline (0.00s)
=== RUN   TestDataClusterImpl_identifyPrimaryBackupNode
=== RUN   TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_no_changes
=== RUN   TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_Only_for_Writer
=== RUN   TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_Only_for_Writer#01
--- PASS: TestDataClusterImpl_identifyPrimaryBackupNode (0.00s)
    --- PASS: TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_Only_for_Writer (0.00s)
    --- PASS: TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_Only_for_Writer#01 (0.00s)
=== RUN   TestDataClusterImpl_processUpAndDownReaders
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_no_changes
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_DOWN_HG_CHANGE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_DOWN_OFFLINE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_TO_MAINTENANCE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_SWAP_READER_TO_WRITER
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_UP_OFFLINE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_UP_HG_CHANGE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_INSERT_READ
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_SWAP_WRITER_TO_READER
--- PASS: TestDataClusterImpl_processUpAndDownReaders (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_DOWN_HG_CHANGE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_DOWN_OFFLINE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_TO_MAINTENANCE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_SWAP_READER_TO_WRITER (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_UP_OFFLINE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_UP_HG_CHANGE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_INSERT_READ (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_SWAP_WRITER_TO_READER (0.00s)
=== RUN   TestDataClusterImpl_processWriterIsAlsoReader
=== RUN   TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_no_changes
=== RUN   TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_WriterIsAlso_reader_=_0_and_2_readers_
=== RUN   TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_WriterIsAlso_reader_=_0_and_1_readers_
--- PASS: TestDataClusterImpl_processWriterIsAlsoReader (0.00s)
    --- PASS: TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_WriterIsAlso_reader_=_0_and_2_readers_ (0.00s)
    --- PASS: TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_WriterIsAlso_reader_=_0_and_1_readers_ (0.00s)
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemove
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_lower_weight_No_action_
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_Higher_weigh_so_another_node_must_go_
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_mid_weigh_so_another_node_must_go_
--- PASS: TestDataClusterImpl_identifyLowerNodeToRemove (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_lower_weight_No_action_ (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_Higher_weigh_so_another_node_must_go_ (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_mid_weigh_so_another_node_must_go_ (0.00s)
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_lower_weight_No_action_
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_Higher_weigh_so_another_node_must_go_
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_mid_weigh_so_no_action_as_well_
--- PASS: TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_lower_weight_No_action_ (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_Higher_weigh_so_another_node_must_go_ (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_mid_weigh_so_no_action_as_well_ (0.00s)
PASS
```