### PR TITLE
Psqladm 381

### DIFF
--- a/internal/DataObjects/dataObjects.go
+++ b/internal/DataObjects/dataObjects.go
@@ -1788,7 +1788,8 @@ func (node *DataNodeImpl) GetConnection() bool {
 			rootCertPool := x509.NewCertPool()
 			pem, err := ioutil.ReadFile(ca)
 			if err != nil {
-				log.Fatal(err)
+				log.Error(err, " While trying to connect to node ", node.Dns)
+				return false
 			}
 			if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
 				log.Fatal("Failed to append PEM.")
@@ -2058,7 +2059,9 @@ func (node DataNodeImpl) getInfo(wg *global.MyWaitGroup, cluster *DataClusterImp
 		global.SetPerformanceObj(fmt.Sprintf("Get info for node %s", node.Dns), true, log.DebugLevel)
 	}
 	// Get the connection
-	node.GetConnection()
+	if !node.GetConnection(){
+		node.NodeTCPDown = true
+	}
 	/*
 		if connection is functioning we try to get the info
 		Otherwise we go on and set node as NOT processed

--- a/internal/DataObjects/dataObjects.go
+++ b/internal/DataObjects/dataObjects.go
@@ -1788,16 +1788,18 @@ func (node *DataNodeImpl) GetConnection() bool {
 			rootCertPool := x509.NewCertPool()
 			pem, err := ioutil.ReadFile(ca)
 			if err != nil {
-				log.Error(err, " While trying to connect to node ", node.Dns)
+				log.Error(err, " While trying to connect to node (CA certificate) ", node.Dns)
 				return false
 			}
 			if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
-				log.Fatal("Failed to append PEM.")
+				log.Error(err, " While trying to connect to node (PEM certificate) ", node.Dns)
+				return false;
 			}
 			clientCert := make([]tls.Certificate, 0, 1)
 			certs, err := tls.LoadX509KeyPair(client, key)
 			if err != nil {
-				log.Fatal(err)
+				log.Error(err, " While trying to connect to node (Key certificate) ", node.Dns)
+				return false
 			}
 			clientCert = append(clientCert, certs)
 			mysql.RegisterTLSConfig("custom", &tls.Config{

--- a/internal/Global/configuration.go
+++ b/internal/Global/configuration.go
@@ -177,6 +177,34 @@ func (conf *Configuration) SanityCheck() bool {
 
 	}
 
+	//check SSL path and certificates
+	if conf.Pxcluster.SslcertificatePath !="" {
+		Separator := string(os.PathSeparator)
+		//var failing = false
+		log.SetReportCaller(false)
+		if !CheckIfPathExists(conf.Pxcluster.SslcertificatePath) {
+			log.Warning(fmt.Sprintf("SSL Path is not accessible currently set to: |%s|", conf.Pxcluster.SslcertificatePath))
+			//failing = true
+		}
+		if !CheckIfPathExists(conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslCa) {
+			log.Warning(fmt.Sprintf("SSLCA Path is not accessible currently set to: |%s|", conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslCa))
+			//failing = true
+		}
+		if !CheckIfPathExists(conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslKey) {
+			log.Warning(fmt.Sprintf("SSL Key Path is not accessible currently set to: |%s|", conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslKey))
+			//failing = true
+		}
+
+		if !CheckIfPathExists(conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslClient) {
+			log.Warning(fmt.Sprintf("SSL Client Path is not accessible currently set to: |%s|", conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslClient))
+			//failing = true
+		}
+		//if failing{
+		//	return false
+		//}
+		return true
+	}
+
 	return true
 
 }

--- a/internal/Global/configuration.go
+++ b/internal/Global/configuration.go
@@ -185,19 +185,20 @@ func (conf *Configuration) SanityCheck() bool {
 		if !CheckIfPathExists(conf.Pxcluster.SslcertificatePath) {
 			log.Warning(fmt.Sprintf("SSL Path is not accessible currently set to: |%s|", conf.Pxcluster.SslcertificatePath))
 			//failing = true
-		}
-		if !CheckIfPathExists(conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslCa) {
-			log.Warning(fmt.Sprintf("SSLCA Path is not accessible currently set to: |%s|", conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslCa))
-			//failing = true
-		}
-		if !CheckIfPathExists(conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslKey) {
-			log.Warning(fmt.Sprintf("SSL Key Path is not accessible currently set to: |%s|", conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslKey))
-			//failing = true
-		}
+		}else {
+			if !CheckIfPathExists(conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslCa) {
+				log.Warning(fmt.Sprintf("SSLCA Path is not accessible currently set to: |%s|", conf.Pxcluster.SslcertificatePath+Separator+conf.Pxcluster.SslCa))
+				//failing = true
+			}
+			if !CheckIfPathExists(conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslKey) {
+				log.Warning(fmt.Sprintf("SSL Key Path is not accessible currently set to: |%s|", conf.Pxcluster.SslcertificatePath+Separator+conf.Pxcluster.SslKey))
+				//failing = true
+			}
 
-		if !CheckIfPathExists(conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslClient) {
-			log.Warning(fmt.Sprintf("SSL Client Path is not accessible currently set to: |%s|", conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslClient))
-			//failing = true
+			if !CheckIfPathExists(conf.Pxcluster.SslcertificatePath + Separator + conf.Pxcluster.SslClient) {
+				log.Warning(fmt.Sprintf("SSL Client Path is not accessible currently set to: |%s|", conf.Pxcluster.SslcertificatePath+Separator+conf.Pxcluster.SslClient))
+				//failing = true
+			}
 		}
 		//if failing{
 		//	return false

--- a/pxc_scheduler_handler.go
+++ b/pxc_scheduler_handler.go
@@ -30,7 +30,7 @@ import (
 	global "pxc_scheduler_handler/internal/Global"
 )
 
-var pxcSchedulerHandlerVersion = "1.3.4"
+var pxcSchedulerHandlerVersion = "1.3.5"
 
 /*
 Main function must contain only initial parameter, log system init and main object init


### PR DESCRIPTION
Merging after QA/mtr and unit tests:
```
==============================================================================
                  TEST NAME                       RESULT  TIME (ms) COMMENT
------------------------------------------------------------------------------
[  1%] proxysql.reader_add1                      [ pass ]  62184
[  3%] proxysql.reader_add1_notdef_conf_hg       [ pass ]  61000
[  5%] proxysql.reader_add2                      [ pass ]  60940
[  7%] proxysql.reader_add3                      [ fail ]
[  7%] proxysql.reader_add3                      [ retry-pass ]  60910
[  7%] proxysql.reader_add3                      [ retry-pass ]  60883
[  9%] proxysql.reader_add4                      [ pass ]  60696
[ 11%] proxysql.reader_desync1                   [ pass ]  61500
[ 13%] proxysql.reader_desync2                   [ pass ]  61470
[ 15%] proxysql.reader_desync3                   [ pass ]  60704
[ 17%] proxysql.reader_desync4                   [ pass ]  61066
[ 19%] proxysql.reader_kill1                     [ pass ]  242351
[ 21%] proxysql.reader_kill2                     [ pass ]  245734
[ 23%] proxysql.reader_kill3                     [ pass ]  243710
[ 25%] proxysql.reader_kill4                     [ pass ]  243684
[ 26%] proxysql.reader_reject_queries1           [ pass ]  60761
[ 28%] proxysql.reader_reject_queries2           [ pass ]  60860
[ 30%] proxysql.reader_reject_queries3           [ pass ]  60708
[ 32%] proxysql.reader_reject_queries4           [ pass ]  61252
[ 34%] proxysql.reader_to_maintenance1           [ pass ]  60835
[ 36%] proxysql.reader_to_maintenance2           [ pass ]  60564
[ 38%] proxysql.reader_to_maintenance3           [ pass ]  61023
[ 40%] proxysql.reader_to_maintenance4           [ pass ]  61457
[ 42%] proxysql.reader_to_readonly1              [ pass ]  60907
[ 44%] proxysql.reader_to_readonly2              [ pass ]  60947
[ 46%] proxysql.reader_to_readonly3              [ pass ]  61652
[ 48%] proxysql.reader_to_readonly4              [ pass ]  61364
[ 50%] proxysql.writer_add1                      [ pass ]  60774
[ 51%] proxysql.writer_add2                      [ pass ]  60815
[ 53%] proxysql.writer_add3                      [ pass ]  61093
[ 55%] proxysql.writer_add4                      [ pass ]  60631
[ 57%] proxysql.writer_desync1                   [ pass ]  60625
[ 59%] proxysql.writer_desync2                   [ pass ]  60766
[ 61%] proxysql.writer_desync3                   [ pass ]  60798
[ 63%] proxysql.writer_desync4                   [ pass ]  60911
[ 65%] proxysql.writer_kill1                     [ pass ]  243739
[ 67%] proxysql.writer_kill1_persist             [ pass ]  244531
[ 69%] proxysql.writer_kill2                     [ pass ]  243402
[ 71%] proxysql.writer_kill2b                    [ pass ]  243951
[ 73%] proxysql.writer_kill3                     [ pass ]  242853
[ 75%] proxysql.writer_kill4                     [ pass ]  243435
[ 76%] proxysql.writer_reject_queries1           [ pass ]  61010
[ 78%] proxysql.writer_reject_queries2           [ pass ]  61319
[ 80%] proxysql.writer_reject_queries3           [ pass ]  61067
[ 82%] proxysql.writer_reject_queries4           [ pass ]  60815
[ 84%] proxysql.writer_to_maintenance1           [ pass ]  60982
[ 86%] proxysql.writer_to_maintenance2           [ pass ]  61254
[ 88%] proxysql.writer_to_maintenance3           [ pass ]  61682
[ 90%] proxysql.writer_to_maintenance4           [ pass ]  60736
[ 92%] proxysql.writer_to_readonly1              [ pass ]  60992
[ 94%] proxysql.writer_to_readonly2              [ pass ]  60948
[ 96%] proxysql.writer_to_readonly3              [ pass ]  61099
[ 98%] proxysql.writer_to_readonly4              [ pass ]  60776
[100%] shutdown_report                           [ pass ]       
------------------------------------------------------------------------------
PXC Scheduler Handler Version:  1.3.5
[tusa@apptest pxc_scheduler_handler]$ go  test ./... -v |grep -v \?|grep -v time
=== RUN   TestLockerImpl_findLock
=== RUN   TestLockerImpl_findLock/Locker_base_disable
=== RUN   TestLockerImpl_findLock/Locker_expire_lock_on_other_node
=== RUN   TestLockerImpl_findLock/Locker_expire_lock_on_other_node_no_previous_lock_on_node
=== RUN   TestLockerImpl_findLock/Locker_lock_is_still_good_on_other_node
=== RUN   TestLockerImpl_findLock/Locker_expire_lock_on_my_node
--- PASS: TestLockerImpl_findLock (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_base_disable (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_expire_lock_on_other_node (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_expire_lock_on_other_node_no_previous_lock_on_node (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_lock_is_still_good_on_other_node (0.00s)
    --- PASS: TestLockerImpl_findLock/Locker_expire_lock_on_my_node (0.00s)
=== RUN   TestDataClusterImpl_checkWsrepDesync
=== RUN   TestDataClusterImpl_checkWsrepDesync/No_change_W
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_in_W_but_only_1
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_in_W_and_2_in_HG
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_in_R_and_1_in_HG
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_in_R_and_2_in_HG
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_2_HG_R_and_Local_Replica_queue_>_MaxReplicationLag
=== RUN   TestDataClusterImpl_checkWsrepDesync/Change_2_HG_R_and_Local_Replica_queue_<_MaxReplicationLag
--- PASS: TestDataClusterImpl_checkWsrepDesync (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/No_change_W (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_in_W_but_only_1 (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_in_W_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_in_R_and_1_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_in_R_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_2_HG_R_and_Local_Replica_queue_>_MaxReplicationLag (0.00s)
    --- PASS: TestDataClusterImpl_checkWsrepDesync/Change_2_HG_R_and_Local_Replica_queue_<_MaxReplicationLag (0.00s)
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/No_change_W
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_W_but_only_1
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_W_and_2_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_R_and_1_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_R_and_2_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_W_but_only_1
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_W_and_2_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_R_and_1_in_HG
=== RUN   TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_R_and_2_in_HG
--- PASS: TestDataClusterImpl_checkAnyNotReadyStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/No_change_W (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_W_but_only_1 (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_W_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_R_and_1_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_1_in_R_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_W_but_only_1 (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_W_and_2_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_R_and_1_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkAnyNotReadyStatus/Change_wsrepstatus_=_3_in_R_and_2_in_HG (0.00s)
=== RUN   TestDataClusterImpl_checkNotPrimary
=== RUN   TestDataClusterImpl_checkNotPrimary/No_WsrepClusterStatus_change_
=== RUN   TestDataClusterImpl_checkNotPrimary/Change_WsrepClusterStatus_=_NOT_Primary_in_W_
--- PASS: TestDataClusterImpl_checkNotPrimary (0.00s)
    --- PASS: TestDataClusterImpl_checkNotPrimary/No_WsrepClusterStatus_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkNotPrimary/Change_WsrepClusterStatus_=_NOT_Primary_in_W_ (0.00s)
=== RUN   TestDataClusterImpl_checkRejectQueries
=== RUN   TestDataClusterImpl_checkRejectQueries/No_WsrepRejectqueries_change_
=== RUN   TestDataClusterImpl_checkRejectQueries/Change_WsrepRejectqueries_=_ALL_in_W_
=== RUN   TestDataClusterImpl_checkRejectQueries/Change_WsrepRejectqueries_=_ALL_in_W_#01
--- PASS: TestDataClusterImpl_checkRejectQueries (0.00s)
    --- PASS: TestDataClusterImpl_checkRejectQueries/No_WsrepRejectqueries_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkRejectQueries/Change_WsrepRejectqueries_=_ALL_in_W_ (0.00s)
    --- PASS: TestDataClusterImpl_checkRejectQueries/Change_WsrepRejectqueries_=_ALL_in_W_#01 (0.00s)
=== RUN   TestDataClusterImpl_checkDonorReject
=== RUN   TestDataClusterImpl_checkDonorReject/No_WsrepDonorrejectqueries_change_
=== RUN   TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_W_HG_size_=_1
=== RUN   TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_W_HG_size_=_2
=== RUN   TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_R_and_1_in_HG
=== RUN   TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_R_and_2_in_HG
--- PASS: TestDataClusterImpl_checkDonorReject (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/No_WsrepDonorrejectqueries_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_W_HG_size_=_1 (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_W_HG_size_=_2 (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_R_and_1_in_HG (0.00s)
    --- PASS: TestDataClusterImpl_checkDonorReject/Change_WsrepDonorrejectqueries_=_true_in_R_and_2_in_HG (0.00s)
=== RUN   TestDataClusterImpl_checkPxcMaint
=== RUN   TestDataClusterImpl_checkPxcMaint/No_PxcMaintMode_change_
=== RUN   TestDataClusterImpl_checkPxcMaint/Change_PxcMaintMode_=_Maintenance
=== RUN   TestDataClusterImpl_checkPxcMaint/Change_PxcMaintMode_=_Maintenance_and_OFFLINE_SOFT
--- PASS: TestDataClusterImpl_checkPxcMaint (0.00s)
    --- PASS: TestDataClusterImpl_checkPxcMaint/No_PxcMaintMode_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkPxcMaint/Change_PxcMaintMode_=_Maintenance (0.00s)
    --- PASS: TestDataClusterImpl_checkPxcMaint/Change_PxcMaintMode_=_Maintenance_and_OFFLINE_SOFT (0.00s)
=== RUN   TestDataClusterImpl_checkReadOnly
=== RUN   TestDataClusterImpl_checkReadOnly/No_ReadOnly_change_
=== RUN   TestDataClusterImpl_checkReadOnly/Change_ReadOnly_=_On_1_writer_
=== RUN   TestDataClusterImpl_checkReadOnly/Change_ReadOnly_=_On_2_writers_
=== RUN   TestDataClusterImpl_checkReadOnly/CChange_ReadOnly_=_On_2_readers_
--- PASS: TestDataClusterImpl_checkReadOnly (0.00s)
    --- PASS: TestDataClusterImpl_checkReadOnly/No_ReadOnly_change_ (0.00s)
    --- PASS: TestDataClusterImpl_checkReadOnly/Change_ReadOnly_=_On_1_writer_ (0.00s)
    --- PASS: TestDataClusterImpl_checkReadOnly/Change_ReadOnly_=_On_2_writers_ (0.00s)
    --- PASS: TestDataClusterImpl_checkReadOnly/CChange_ReadOnly_=_On_2_readers_ (0.00s)
=== RUN   TestDataClusterImpl_checkBackOffLine
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_no_changes_
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_WsrepStatus
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_ProxyStatus
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_WsrepClusterStatus
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_PxcMaintMode
=== RUN   TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_PxcMaintMode#01
--- PASS: TestDataClusterImpl_checkBackOffLine (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_no_changes_ (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_WsrepStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_ProxyStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_WsrepClusterStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_PxcMaintMode (0.00s)
    --- PASS: TestDataClusterImpl_checkBackOffLine/Back_from_OFFLINE_SOFT_change_PxcMaintMode#01 (0.00s)
=== RUN   TestDataClusterImpl_checkBackDesyncButUnderReplicaLag
=== RUN   TestDataClusterImpl_checkBackDesyncButUnderReplicaLag/Back_from_OFFLINE_SOFT_no_changes_
=== RUN   TestDataClusterImpl_checkBackDesyncButUnderReplicaLag/Back_from_OFFLINE_SOFT__when_Local_Replica_queue_<_of_50%_MaxReplicationLag
--- PASS: TestDataClusterImpl_checkBackDesyncButUnderReplicaLag (0.00s)
    --- PASS: TestDataClusterImpl_checkBackDesyncButUnderReplicaLag/Back_from_OFFLINE_SOFT_no_changes_ (0.00s)
    --- PASS: TestDataClusterImpl_checkBackDesyncButUnderReplicaLag/Back_from_OFFLINE_SOFT__when_Local_Replica_queue_<_of_50%_MaxReplicationLag (0.00s)
=== RUN   TestDataClusterImpl_checkBackNew
=== RUN   TestDataClusterImpl_checkBackNew/Backup_Node_has_lower_weight_No_action_
=== RUN   TestDataClusterImpl_checkBackNew/Back_online_Node_is_new_no_changes_
--- PASS: TestDataClusterImpl_checkBackNew (0.00s)
    --- PASS: TestDataClusterImpl_checkBackNew/Backup_Node_has_lower_weight_No_action_ (0.00s)
    --- PASS: TestDataClusterImpl_checkBackNew/Back_online_Node_is_new_no_changes_ (0.00s)
=== RUN   TestDataClusterImpl_checkBackPrimary
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_no_changes
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepStatus
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_HostgroupId
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepClusterStatus
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_PxcMaintMode
=== RUN   TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepRejectqueries
--- PASS: TestDataClusterImpl_checkBackPrimary (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_HostgroupId (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepClusterStatus (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_PxcMaintMode (0.00s)
    --- PASS: TestDataClusterImpl_checkBackPrimary/Back_online_Node_from_Maintenance_HG_change_WsrepRejectqueries (0.00s)
=== RUN   TestDataClusterImpl_cleanWriters
=== RUN   TestDataClusterImpl_cleanWriters/Check_evaluateWriters_-_cleanWriters_no_changes
=== RUN   TestDataClusterImpl_cleanWriters/Check_evaluateWriters_-_cleanWriters_One_node_is_offline
--- PASS: TestDataClusterImpl_cleanWriters (0.00s)
    --- PASS: TestDataClusterImpl_cleanWriters/Check_evaluateWriters_-_cleanWriters_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_cleanWriters/Check_evaluateWriters_-_cleanWriters_One_node_is_offline (0.00s)
=== RUN   TestDataClusterImpl_identifyPrimaryBackupNode
=== RUN   TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_no_changes
=== RUN   TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_Only_for_Writer
=== RUN   TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_Only_for_Writer#01
--- PASS: TestDataClusterImpl_identifyPrimaryBackupNode (0.00s)
    --- PASS: TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_Only_for_Writer (0.00s)
    --- PASS: TestDataClusterImpl_identifyPrimaryBackupNode/Check_evaluateWriters_-_Identify_Primary_Only_for_Writer#01 (0.00s)
=== RUN   TestDataClusterImpl_processUpAndDownReaders
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_no_changes
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_DOWN_HG_CHANGE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_DOWN_OFFLINE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_TO_MAINTENANCE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_SWAP_READER_TO_WRITER
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_UP_OFFLINE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_UP_HG_CHANGE
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_INSERT_READ
=== RUN   TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_SWAP_WRITER_TO_READER
--- PASS: TestDataClusterImpl_processUpAndDownReaders (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_DOWN_HG_CHANGE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_DOWN_OFFLINE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_TO_MAINTENANCE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_SWAP_READER_TO_WRITER (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_UP_OFFLINE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_UP_HG_CHANGE (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_INSERT_READ (0.00s)
    --- PASS: TestDataClusterImpl_processUpAndDownReaders/Check_evaluateReaders_-_ProcessUpAndDownReaders_MOVE_SWAP_WRITER_TO_READER (0.00s)
=== RUN   TestDataClusterImpl_processWriterIsAlsoReader
=== RUN   TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_no_changes
=== RUN   TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_WriterIsAlso_reader_=_0_and_2_readers_
=== RUN   TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_WriterIsAlso_reader_=_0_and_1_readers_
--- PASS: TestDataClusterImpl_processWriterIsAlsoReader (0.00s)
    --- PASS: TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_no_changes (0.00s)
    --- PASS: TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_WriterIsAlso_reader_=_0_and_2_readers_ (0.00s)
    --- PASS: TestDataClusterImpl_processWriterIsAlsoReader/Check_evaluateReaders_-_processWriterIsAlsoReader_WriterIsAlso_reader_=_0_and_1_readers_ (0.00s)
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemove
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_lower_weight_No_action_
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_Higher_weigh_so_another_node_must_go_
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_mid_weigh_so_another_node_must_go_
--- PASS: TestDataClusterImpl_identifyLowerNodeToRemove (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_lower_weight_No_action_ (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_Higher_weigh_so_another_node_must_go_ (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemove/Backup_Node_has_mid_weigh_so_another_node_must_go_ (0.00s)
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_lower_weight_No_action_
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_Higher_weigh_so_another_node_must_go_
=== RUN   TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_mid_weigh_so_no_action_as_well_
--- PASS: TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_lower_weight_No_action_ (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_Higher_weigh_so_another_node_must_go_ (0.00s)
    --- PASS: TestDataClusterImpl_identifyLowerNodeToRemoveBecauseFailback/Failback_Node_has_mid_weigh_so_no_action_as_well_ (0.00s)
PASS
ok  	pxc_scheduler_handler/internal/DataObjects	0.009s
```