### PR TITLE
Fixing wrong exit when demonised

### DIFF
--- a/pxc_scheduler_handler.go
+++ b/pxc_scheduler_handler.go
@@ -232,9 +232,10 @@ func main() {
 		} else {
 			i++
 		}
-		exitWithCode(0)
 
 	}
+
+	exitWithCode(0)
 	//if !config.global.Development {
 	//	locker.RemoveLockFile()
 	//}


### PR DESCRIPTION
Given the new wrapper on exit the position of the exit command was not correct when the scheduler is running as daemon 