### PR TITLE
Replace log.Fatal with log.Error

### DIFF
--- a/internal/DataObjects/dataObjects.go
+++ b/internal/DataObjects/dataObjects.go
@@ -322,7 +322,7 @@ func (cluster *DataClusterImpl) init(config global.Configuration, connectionProx
 
 		// Consolidate HGs is required to calculate the real status BY HG of the size of the group and other info
 		if !cluster.consolidateHGs() {
-			log.Fatal("Cannot load Hostgroups in cluster object. Exiting")
+			log.Error("Cannot load Hostgroups in cluster object. Exiting")
 			return false
 			//os.Exit(1)
 		}

--- a/internal/DataObjects/proxySQLObjects.go
+++ b/internal/DataObjects/proxySQLObjects.go
@@ -409,7 +409,7 @@ func (node *ProxySQLNodeImpl) ProcessChanges() bool {
 	}
 
 	if !node.executeSQLChanges(SQLActionString) {
-		log.Fatal("Cannot apply changes error in SQL execution in ProxySQL, Exit with error")
+		log.Error("Cannot apply changes error in SQL execution in ProxySQL, Exit with error")
 		return false
 		//os.Exit(1)
 	}
@@ -548,33 +548,33 @@ func (node *ProxySQLNodeImpl) executeSQLChanges(SQLActionString []string) bool {
 	ctx := context.Background()
 	tx, err := node.Connection.BeginTx(ctx, nil)
 	if err != nil {
-		log.Fatal("Error in creating transaction to push changes ", err)
+		log.Error("Error in creating transaction to push changes: ", err)
+		return false
 	}
 	for i := 0; i < len(SQLActionString); i++ {
 		if SQLActionString[i] != "" {
 			_, err = tx.ExecContext(ctx, SQLActionString[i])
 			if err != nil {
 				tx.Rollback()
-				log.Fatal("Error executing SQL: ", SQLActionString[i], " Rollback and exit")
-				log.Error(err)
+				log.Error("Error executing SQL: ", SQLActionString[i], " : ", err, ", Rollback and exit")
 				return false
 			}
 		}
 	}
 	err = tx.Commit()
 	if err != nil {
-		log.Fatal("Error IN COMMIT exit")
+		log.Error("Error IN COMMIT exit: ", err)
 		return false
 
 	} else {
 		_, err = node.Connection.Exec("LOAD mysql servers to RUN ")
 		if err != nil {
-			log.Fatal("Cannot load new mysql configuration to RUN ")
+			log.Error("Cannot load new mysql configuration to RUN: ", err)
 			return false
 		} else {
 			_, err = node.Connection.Exec("SAVE mysql servers to DISK ")
 			if err != nil {
-				log.Fatal("Cannot save new mysql configuration to DISK ")
+				log.Error("Cannot save new mysql configuration to DISK: ", err)
 				return false
 			}
 		}

--- a/internal/Global/configuration.go
+++ b/internal/Global/configuration.go
@@ -132,14 +132,14 @@ func (conf *Configuration) SanityCheck() bool {
 	if conf.Pxcluster.MaxNumWriters > 1 &&
 		conf.Pxcluster.SinglePrimary {
 		log.SetReportCaller(true)
-		log.Fatal("Configuration error cannot have SinglePrimary true and MaxNumWriter >1")
+		log.Error("Configuration error cannot have SinglePrimary true and MaxNumWriter >1")
 		return false
 		//os.Exit(1)
 	}
 
 	if conf.Pxcluster.WriterIsAlsoReader != 1 && (conf.Pxcluster.MaxWriters > 1 || !conf.Pxcluster.SinglePrimary) {
 		log.SetReportCaller(true)
-		log.Fatal("Configuration error cannot have WriterIsAlsoReader NOT = 1 and use more than one Writer")
+		log.Error("Configuration error cannot have WriterIsAlsoReader NOT = 1 and use more than one Writer")
 		return false
 		//os.Exit(1)
 	}
@@ -170,7 +170,7 @@ func (conf *Configuration) SanityCheck() bool {
 		conf.Proxysql.LockFilePath = "/tmp"
 		if !CheckIfPathExists(conf.Proxysql.LockFilePath) {
 			log.SetReportCaller(true)
-			log.Fatal(fmt.Sprintf("LockFilePath is not accessible currently set to: |%s|", conf.Proxysql.LockFilePath))
+			log.Error(fmt.Sprintf("LockFilePath is not accessible currently set to: |%s|", conf.Proxysql.LockFilePath))
 			return false
 			//os.Exit(1)
 		}


### PR DESCRIPTION
Using log.Fatal leads to immediate interruption and breaks lock cleanup.