### PR TITLE
Use PingContext instead of Ping

### DIFF
--- a/internal/DataObjects/dataObjects.go
+++ b/internal/DataObjects/dataObjects.go
@@ -18,6 +18,7 @@
 package DataObjects
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
@@ -1826,7 +1827,10 @@ func (node *DataNodeImpl) GetConnection() bool {
 	}
 
 	// Open doesn't open a connection. Validate DSN data:
-	err = db.Ping()
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err = db.PingContext(ctx)
 	if err != nil {
 		log.Error(err.Error())
 		node.NodeTCPDown = true

--- a/internal/DataObjects/proxySQLObjects.go
+++ b/internal/DataObjects/proxySQLObjects.go
@@ -26,6 +26,7 @@ import (
 	global "pxc_scheduler_handler/internal/Global"
 	SQL "pxc_scheduler_handler/internal/Sql/Proxy"
 	"strconv"
+	"time"
 )
 
 /*
@@ -244,7 +245,10 @@ func (node *ProxySQLNodeImpl) GetConnection() bool {
 	}
 
 	// Open doesn't open a connection. Validate DSN data:
-	err = db.Ping()
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err = db.PingContext(ctx)
 	if err != nil {
 		err.Error()
 		log.Error(err)


### PR DESCRIPTION
In some situations, for example when server works under heavy load scheduler can stuck on db.Ping forever.
Seems like it better to use PingContext with context.WithTimeout instead of Ping to prevent that.

<details><summary>Here is the trace of stuck scheduler:</summary>
<p>

```(dlv) goroutine 1 stack
 0  0x0000000000438eb6 in runtime.gopark
    at /usr/local/go/src/runtime/proc.go:364
 1  0x0000000000431a77 in runtime.netpollblock
    at /usr/local/go/src/runtime/netpoll.go:526
 2  0x0000000000460c09 in internal/poll.runtime_pollWait
    at /usr/local/go/src/runtime/netpoll.go:305
 3  0x00000000004aa792 in internal/poll.(*pollDesc).wait
    at /usr/local/go/src/internal/poll/fd_poll_runtime.go:84
 4  0x00000000004ab31a in internal/poll.(*pollDesc).waitRead
    at /usr/local/go/src/internal/poll/fd_poll_runtime.go:89
 5  0x00000000004ab31a in internal/poll.(*FD).Read
    at /usr/local/go/src/internal/poll/fd_unix.go:167
 6  0x0000000000532169 in net.(*netFD).Read
    at /usr/local/go/src/net/fd_posix.go:55
 7  0x000000000053d065 in net.(*conn).Read
    at /usr/local/go/src/net/net.go:183
 8  0x000000000063237a in github.com/go-sql-driver/mysql.(*buffer).fill
    at /tmp/pkg/mod/github.com/go-sql-driver/mysql@v1.5.0/buffer.go:90
 9  0x00000000006324ad in github.com/go-sql-driver/mysql.(*buffer).readNext
    at /tmp/pkg/mod/github.com/go-sql-driver/mysql@v1.5.0/buffer.go:119
10  0x000000000063aba5 in github.com/go-sql-driver/mysql.(*mysqlConn).readPacket
    at /tmp/pkg/mod/github.com/go-sql-driver/mysql@v1.5.0/packets.go:31
11  0x000000000063b893 in github.com/go-sql-driver/mysql.(*mysqlConn).readHandshakePacket
    at /tmp/pkg/mod/github.com/go-sql-driver/mysql@v1.5.0/packets.go:187
12  0x0000000000636f65 in github.com/go-sql-driver/mysql.(*connector).Connect
    at /tmp/pkg/mod/github.com/go-sql-driver/mysql@v1.5.0/connector.go:81
13  0x000000000062a4a3 in database/sql.(*DB).conn
    at /usr/local/go/src/database/sql/sql.go:1393
14  0x0000000000628878 in database/sql.(*DB).PingContext
    at /usr/local/go/src/database/sql/sql.go:851
Sending output to pager...
 0  0x0000000000438eb6 in runtime.gopark
    at /usr/local/go/src/runtime/proc.go:364
 1  0x0000000000431a77 in runtime.netpollblock
    at /usr/local/go/src/runtime/netpoll.go:526
 2  0x0000000000460c09 in internal/poll.runtime_pollWait
    at /usr/local/go/src/runtime/netpoll.go:305
 3  0x00000000004aa792 in internal/poll.(*pollDesc).wait
    at /usr/local/go/src/internal/poll/fd_poll_runtime.go:84
 4  0x00000000004ab31a in internal/poll.(*pollDesc).waitRead
    at /usr/local/go/src/internal/poll/fd_poll_runtime.go:89
 5  0x00000000004ab31a in internal/poll.(*FD).Read
    at /usr/local/go/src/internal/poll/fd_unix.go:167
 6  0x0000000000532169 in net.(*netFD).Read
    at /usr/local/go/src/net/fd_posix.go:55
 7  0x000000000053d065 in net.(*conn).Read
    at /usr/local/go/src/net/net.go:183
 8  0x000000000063237a in github.com/go-sql-driver/mysql.(*buffer).fill
    at /tmp/pkg/mod/github.com/go-sql-driver/mysql@v1.5.0/buffer.go:90
 9  0x00000000006324ad in github.com/go-sql-driver/mysql.(*buffer).readNext
    at /tmp/pkg/mod/github.com/go-sql-driver/mysql@v1.5.0/buffer.go:119
10  0x000000000063aba5 in github.com/go-sql-driver/mysql.(*mysqlConn).readPacket
    at /tmp/pkg/mod/github.com/go-sql-driver/mysql@v1.5.0/packets.go:31
11  0x000000000063b893 in github.com/go-sql-driver/mysql.(*mysqlConn).readHandshakePacket
    at /tmp/pkg/mod/github.com/go-sql-driver/mysql@v1.5.0/packets.go:187
12  0x0000000000636f65 in github.com/go-sql-driver/mysql.(*connector).Connect
    at /tmp/pkg/mod/github.com/go-sql-driver/mysql@v1.5.0/connector.go:81
13  0x000000000062a4a3 in database/sql.(*DB).conn
    at /usr/local/go/src/database/sql/sql.go:1393
14  0x0000000000628878 in database/sql.(*DB).PingContext
    at /usr/local/go/src/database/sql/sql.go:851
15  0x000000000065da05 in database/sql.(*DB).Ping
15  0x000000000065da05 in database/sql.(*DB).Ping
    at /usr/local/go/src/database/sql/sql.go:873
16  0x000000000065da05 in pxc_scheduler_handler/internal/DataObjects.(*ProxySQLNodeImpl).GetConnection
    at /tmp/build/internal/DataObjects/proxySQLObjects.go:247
17  0x000000000065d1d3 in pxc_scheduler_handler/internal/DataObjects.(*ProxySQLNodeImpl).Init
    at /tmp/build/internal/DataObjects/proxySQLObjects.go:158
18  0x0000000000648ed2 in pxc_scheduler_handler/internal/DataObjects.(*LockerImpl).CheckClusterLock
    at /tmp/build/internal/DataObjects/Locker.go:305
19  0x0000000000662adb in main.main
    at /tmp/build/pxc_scheduler_handler.go:172
20  0x0000000000438af2 in runtime.main
    at /usr/local/go/src/runtime/proc.go:250
21  0x0000000000465981 in runtime.goexit
    at /usr/local/go/src/runtime/asm_amd64.s:1594

```
</p>
</details>