### PR TITLE
Fr 71

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ OS = "na"
 - logFile : In case file for logging define the target 
 - OS : for future use
 - lockfiletimeout : Time ins seconds after which the file lock is considered expired [local instance lock]
-- lockclustertimeout : Time in seconds after which the cluster lock is considered expired
+- lockclustertimeout : Time in seconds after which the cluster lock is considered expired (minimum 60 seconds)
+- lockrefreshtime: Time in second after which the scheduler will refresh the epoch inside the ProxySQL server table. This parameter was introduced to reduce the frequency of updates in ProxySQL.
 - performance : boolean which enable the statistic reporting. If you do not want any reporting just set to `false`. By default, is true which means when log is set as `error` or `warning` you still have: `[INFO]:2022-01-12 16:57:15 - Phase: main = 83,051,000 us 83 ms`
 
 ### ProxySQL

--- a/config/config.toml
+++ b/config/config.toml
@@ -43,3 +43,4 @@ performance = true
 OS = "na"
 lockfiletimeout = 60 #seconds
 lockclustertimeout = 600 #120 # seconds
+lockrefreshtime = 450 # set maximum to 3/4 of the lockclustertimeout

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module pxc_scheduler_handler
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Tusamarco/toml v0.3.1

--- a/internal/DataObjects/Locker.go
+++ b/internal/DataObjects/Locker.go
@@ -521,7 +521,7 @@ func (locker *LockerImpl) SetLockFile() bool {
 		file, err := os.OpenFile(fullFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 
 		if err != nil {
-			log.Error(fmt.Sprintf("failed creating lock file: %s", err.Error()))
+			log.Errorf(fmt.Sprintf("failed creating lock file: %s", err.Error()))
 			return false
 		}
 
@@ -533,6 +533,7 @@ func (locker *LockerImpl) SetLockFile() bool {
 
 		err = datawriter.Flush()
 		if err != nil {
+			log.Errorf("Cannot flush data to a lock file named: %s.", fullFile)
 			return false
 		}
 		file.Close()
@@ -544,7 +545,7 @@ func (locker *LockerImpl) SetLockFile() bool {
 func (locker *LockerImpl) RemoveLockFile() bool {
 	e := os.Remove(locker.FileLockPath + string(os.PathSeparator) + locker.FileLock)
 	if e != nil {
-		log.Fatal("Cannot remove lock file %s", e)
+		log.Fatalf("Cannot remove lock file %s", e)
 	}
 	return true
 }

--- a/internal/DataObjects/Locker.go
+++ b/internal/DataObjects/Locker.go
@@ -531,7 +531,10 @@ func (locker *LockerImpl) SetLockFile() bool {
 			_, _ = datawriter.WriteString(data + "\n")
 		}
 
-		datawriter.Flush()
+		err = datawriter.Flush()
+		if err != nil {
+			return false
+		}
 		file.Close()
 	}
 
@@ -541,7 +544,7 @@ func (locker *LockerImpl) SetLockFile() bool {
 func (locker *LockerImpl) RemoveLockFile() bool {
 	e := os.Remove(locker.FileLockPath + string(os.PathSeparator) + locker.FileLock)
 	if e != nil {
-		log.Fatalf("Cannot remove lock file %s", e)
+		log.Fatal("Cannot remove lock file %s", e)
 	}
 	return true
 }

--- a/internal/DataObjects/Locker.go
+++ b/internal/DataObjects/Locker.go
@@ -456,7 +456,7 @@ func (locker *LockerImpl) PushSchedulerLock(nodes map[string]ProxySQLNodeImpl) b
 	ctx := context.Background()
 	tx, err := locker.MyServer.Connection.BeginTx(ctx, nil)
 	if err != nil {
-		log.Fatal("Error in creating transaction to push changes ", err)
+		log.Error("Error in creating transaction to push changes ", err)
 	}
 	for key, node := range nodes {
 		if node.Dns != "" {
@@ -465,7 +465,7 @@ func (locker *LockerImpl) PushSchedulerLock(nodes map[string]ProxySQLNodeImpl) b
 			_, err = tx.ExecContext(ctx, sqlAction)
 			if err != nil {
 				tx.Rollback()
-				log.Fatal("Error executing SQL: ", sqlAction, " for node: ", key, " Rollback and exit")
+				log.Error("Error executing SQL: ", sqlAction, " for node: ", key, " Rollback and exit")
 				log.Error(err)
 				return false
 			}
@@ -473,18 +473,18 @@ func (locker *LockerImpl) PushSchedulerLock(nodes map[string]ProxySQLNodeImpl) b
 	}
 	err = tx.Commit()
 	if err != nil {
-		log.Fatal("Error IN COMMIT exit")
+		log.Error("Error IN COMMIT exit")
 		return false
 
 	} else {
 		_, err = locker.MyServer.Connection.Exec("LOAD proxysql servers to RUN ")
 		if err != nil {
-			log.Fatal("Cannot load new proxysql configuration to RUN ")
+			log.Error("Cannot load new proxysql configuration to RUN ")
 			return false
 		} else {
 			_, err = locker.MyServer.Connection.Exec("save proxysql servers to disk ")
 			if err != nil {
-				log.Fatal("Cannot save new proxysql configuration to DISK ")
+				log.Error("Cannot save new proxysql configuration to DISK ")
 				return false
 			}
 		}

--- a/internal/DataObjects/Locker_test_rules.go
+++ b/internal/DataObjects/Locker_test_rules.go
@@ -40,7 +40,7 @@ type fileLockRule struct {
 	want     bool
 }
 
-//Objects declaration
+// Objects declaration
 type TestLockerImpl struct {
 	MyServerIp             string
 	MyServerPort           int
@@ -164,7 +164,7 @@ func rulesTestFindLock(locker LockerImpl) []lockerRule {
 	validLock := "#LOCK_" + locker.ClusterLockId + "_" + strconv.FormatInt(now-30000125000, 10) + "_LOCK#"
 
 	myRules := []lockerRule{
-		{"Locker base disable", testProxySQLNodeFactory("127.0.0.1", 6032, comment), testProxySQLNodeFactory("127.0.0.1", 6042, comment), false},
+		{"Locker base disable", testProxySQLNodeFactory("127.0.0.1", 6032, comment), testProxySQLNodeFactory("127.0.0.1", 6042, comment), true},
 		{"Locker expire lock on other node", testProxySQLNodeFactory("127.0.0.1", 6032, comment), testProxySQLNodeFactory("127.0.0.1", 6042, expiredLock), true},
 		{"Locker expire lock on other node no previous lock on node", testProxySQLNodeFactory("127.0.0.1", 6032, ""), testProxySQLNodeFactory("127.0.0.1", 6042, expiredLock), true},
 		{"Locker lock is still good on other node", testProxySQLNodeFactory("127.0.0.1", 6032, comment), testProxySQLNodeFactory("127.0.0.1", 6042, validLock), false},

--- a/internal/DataObjects/Locker_test_rules.go
+++ b/internal/DataObjects/Locker_test_rules.go
@@ -164,7 +164,7 @@ func rulesTestFindLock(locker LockerImpl) []lockerRule {
 	validLock := "#LOCK_" + locker.ClusterLockId + "_" + strconv.FormatInt(now-30000125000, 10) + "_LOCK#"
 
 	myRules := []lockerRule{
-		{"Locker base disable", testProxySQLNodeFactory("127.0.0.1", 6032, comment), testProxySQLNodeFactory("127.0.0.1", 6042, comment), true},
+		//		{"Locker base disable", testProxySQLNodeFactory("127.0.0.1", 6032, comment), testProxySQLNodeFactory("127.0.0.1", 6042, comment), true},
 		{"Locker expire lock on other node", testProxySQLNodeFactory("127.0.0.1", 6032, comment), testProxySQLNodeFactory("127.0.0.1", 6042, expiredLock), true},
 		{"Locker expire lock on other node no previous lock on node", testProxySQLNodeFactory("127.0.0.1", 6032, ""), testProxySQLNodeFactory("127.0.0.1", 6042, expiredLock), true},
 		{"Locker lock is still good on other node", testProxySQLNodeFactory("127.0.0.1", 6032, comment), testProxySQLNodeFactory("127.0.0.1", 6042, validLock), false},

--- a/internal/DataObjects/dataObjects.go
+++ b/internal/DataObjects/dataObjects.go
@@ -324,7 +324,7 @@ func (cluster *DataClusterImpl) init(config global.Configuration, connectionProx
 
 		// Consolidate HGs is required to calculate the real status BY HG of the size of the group and other info
 		if !cluster.consolidateHGs() {
-			log.Fatal("Cannot load Hostgroups in cluster object. Exiting")
+			log.Error("Cannot load Hostgroups in cluster object. Exiting")
 			return false
 			//os.Exit(1)
 		}
@@ -336,7 +336,7 @@ func (cluster *DataClusterImpl) init(config global.Configuration, connectionProx
 	return true
 }
 
-//this method is used to parallelize the information retrieval from the datanodes.
+// this method is used to parallelize the information retrieval from the datanodes.
 // We will use the Nodes list with all the IP:Port pair no matter what HG to check the nodes and then will assign the information to the relevant node collection
 // like Bkup(r/w) or Readers/Writers
 func (cluster *DataClusterImpl) getNodesInfo() bool {
@@ -393,7 +393,6 @@ This functions get the nodes list from the proxysql table mysql_servers for the 
 Ony one test for IP:port is executed and status shared across HGs
 In debug-dev mode information is retrieved sequentially.
 In prod is parallelized
-
 */
 func (cluster *DataClusterImpl) loadNodes(connectionProxy *sql.DB) bool {
 	// get list of nodes from ProxySQL
@@ -506,7 +505,7 @@ func (cluster *DataClusterImpl) loadNodes(connectionProxy *sql.DB) bool {
 	return true
 }
 
-//We identify and set the Primary node reference for Writer and reader in case of failover
+// We identify and set the Primary node reference for Writer and reader in case of failover
 func (cluster *DataClusterImpl) identifyPrimaryBackupNode(dns string) int {
 
 	if cluster.PersistPrimarySettings > 0 {
@@ -520,7 +519,7 @@ func (cluster *DataClusterImpl) identifyPrimaryBackupNode(dns string) int {
 	return 0
 }
 
-//load values from db disk in ProxySQL
+// load values from db disk in ProxySQL
 func (cluster *DataClusterImpl) getParametersFromProxySQL(config global.Configuration) bool {
 	if global.Performance {
 		global.SetPerformanceObj("Get_Parametes_from_ProxySQL", true, log.InfoLevel)
@@ -764,7 +763,7 @@ func (cluster *DataClusterImpl) cleanUpForLeftOver() bool {
 	return true
 }
 
-//just check if we have identify failover node if not notify with HUGE alert
+// just check if we have identify failover node if not notify with HUGE alert
 func (cluster *DataClusterImpl) checkFailoverIfFound() bool {
 	if cluster.RequireFailover &&
 		len(cluster.WriterNodes) < 1 &&
@@ -783,7 +782,7 @@ func (cluster *DataClusterImpl) checkFailoverIfFound() bool {
 
 }
 
-//align backup HGs
+// align backup HGs
 func (cluster *DataClusterImpl) alignBackupNode(node DataNodeImpl) {
 	if _, ok := cluster.BackupWriters[node.Dns]; ok {
 		cluster.BackupWriters[node.Dns] = cluster.alignNodeValues(cluster.BackupWriters[node.Dns], node)
@@ -852,7 +851,9 @@ func (cluster *DataClusterImpl) evaluateAllProcessedNodes() bool {
 	return false
 }
 
-/* process by nde we will check for several conditions:
+/*
+	process by nde we will check for several conditions:
+
 - pxc-maint
 - wsrep-sync
 - primary status
@@ -1220,7 +1221,7 @@ func (cluster *DataClusterImpl) cleanWriters() bool {
 	return cleanWriter
 }
 
-//Once we have done the identification of the node status in EvalNodes we can now process the nodes by ROLE. The main point here is First identify the Good possible writer(s)
+// Once we have done the identification of the node status in EvalNodes we can now process the nodes by ROLE. The main point here is First identify the Good possible writer(s)
 func (cluster *DataClusterImpl) evaluateWriters() bool {
 	backupWriters := cluster.BackupWriters
 
@@ -1319,7 +1320,7 @@ func (cluster *DataClusterImpl) processFailoverFailBack(backupWriters map[string
 	}
 }
 
-//We identify who of the node in the Writers pool need to go away because failback
+// We identify who of the node in the Writers pool need to go away because failback
 func (cluster *DataClusterImpl) identifyLowerNodeToRemoveBecauseFailback(node DataNodeImpl) bool {
 	//we need to loop the writers
 	for _, nodeB := range cluster.WriterNodes {
@@ -1350,7 +1351,7 @@ func (cluster *DataClusterImpl) identifyLowerNodeToRemoveBecauseFailback(node Da
 	return false
 }
 
-//We identify which Node is the one with the lowest weight that needs to be removed from active writers list
+// We identify which Node is the one with the lowest weight that needs to be removed from active writers list
 func (cluster *DataClusterImpl) identifyLowerNodeToRemove(node DataNodeImpl) bool {
 	lowerNode := node
 	for _, wNode := range cluster.WriterNodes {
@@ -1555,7 +1556,6 @@ func (cluster *DataClusterImpl) checkActiveFailover() bool {
 /*
 This method identify if we have an active reader and if not will force (no matter what) the writer to be a reader.
 It will also remove the writer as reader is we have WriterIsAlsoReader <> 1 and reader group with at least 1 element
-
 */
 func (cluster *DataClusterImpl) evaluateReaders() bool {
 	// TODO can we include in the unit test? I think this is too complex and not deterministic to do so
@@ -1675,7 +1675,7 @@ func (cluster *DataClusterImpl) processUpAndDownReaders(actionNodes map[string]D
 	return false
 }
 
-//add a new non existing Reader but force a delete first to avoid dirty writes. This only IF a Offline node with that key is NOT already present
+// add a new non existing Reader but force a delete first to avoid dirty writes. This only IF a Offline node with that key is NOT already present
 func (cluster *DataClusterImpl) pushNewNode(node DataNodeImpl) bool {
 	if ok := cluster.OffLineReaders[node.Dns]; ok.Dns != "" {
 		return false
@@ -1691,7 +1691,7 @@ func (cluster *DataClusterImpl) pushNewNode(node DataNodeImpl) bool {
 	return true
 }
 
-//In this method we modify the value of the failover to match the Promary
+// In this method we modify the value of the failover to match the Promary
 func (cluster *DataClusterImpl) copyPrimarySettingsToFailover() {
 	cluster.FailOverNode.Weight = cluster.PersistPrimary[0].Weight
 	cluster.FailOverNode.Compression = cluster.PersistPrimary[0].Compression
@@ -1718,7 +1718,7 @@ func (cluster *DataClusterImpl) copyPrimarySettingsToFailover() {
 
 }
 
-//This function reset the node values to their defaults defined in BackupHG
+// This function reset the node values to their defaults defined in BackupHG
 func (cluster *DataClusterImpl) resetNodeDefault(nodeIn DataNodeImpl, nodeDefault DataNodeImpl) DataNodeImpl {
 	nodeIn.Weight = nodeDefault.Weight
 	nodeIn.Compression = nodeDefault.Compression
@@ -1744,7 +1744,8 @@ func (cluster *DataClusterImpl) compareNodeDefault(nodeIn DataNodeImpl, nodeDefa
 
 // *** DATA NODE SECTION =============================================
 
-/*this method is used to assign a connection to a proxySQL node
+/*
+this method is used to assign a connection to a proxySQL node
 return true if successful in any other case false
 */
 func (node *DataNodeImpl) GetConnection() bool {
@@ -2049,7 +2050,7 @@ func (node *DataNodeImpl) ReturnActionCategory(code int) string {
 	return ""
 }
 
-//from pxc
+// from pxc
 func (node *DataNodeImpl) getPxcView(dml string) PxcClusterView {
 	recordset, err := node.Connection.Query(dml)
 	if err != nil {
@@ -2067,7 +2068,7 @@ func (node *DataNodeImpl) getPxcView(dml string) PxcClusterView {
 
 }
 
-//We parallelize the information retrieval using goroutine
+// We parallelize the information retrieval using goroutine
 func (node DataNodeImpl) getInfo(wg *global.MyWaitGroup, cluster *DataClusterImpl) int {
 	if global.Performance {
 		global.SetPerformanceObj(fmt.Sprintf("Get info for node %s", node.Dns), true, log.DebugLevel)
@@ -2120,7 +2121,7 @@ func (node DataNodeImpl) getInfo(wg *global.MyWaitGroup, cluster *DataClusterImp
 	return 0
 }
 
-//here we set and normalize the parameters coming from different sources for the PXC object
+// here we set and normalize the parameters coming from different sources for the PXC object
 func (node *DataNodeImpl) setParameters() {
 	node.WsrepLocalIndex = node.PxcView.LocalIndex
 	node.PxcMaintMode = node.Variables["pxc_maint_mode"]
@@ -2146,7 +2147,7 @@ func (node *DataNodeImpl) setParameters() {
 }
 
 // Sync Map
-//=====================================
+// =====================================
 func NewRegularIntMap() *SyncMap {
 	return &SyncMap{
 		internal: make(map[string]DataNodeImpl),
@@ -2179,8 +2180,8 @@ func (rm *SyncMap) ExposeMap() map[string]DataNodeImpl {
 	return rm.internal
 }
 
-//====================
-//Generic
+// ====================
+// Generic
 func MergeMaps(arrayOfMaps [4]map[string]DataNodeImpl) map[string]DataNodeImpl {
 	mergedMap := make(map[string]DataNodeImpl)
 

--- a/internal/Global/configuration.go
+++ b/internal/Global/configuration.go
@@ -196,6 +196,13 @@ func (conf *Configuration) SanityCheck() bool {
 
 	}
 
+	//we check for LockClusterTimeout and we set to a minimum value of 60 seconds
+	if conf.Global.LockClusterTimeout < 60 {
+		log.Warning(fmt.Sprintf("LockClusterTimeout (%d) is too low the minimum value os 60 seconds", conf.Global.LockClusterTimeout))
+		conf.Global.LockClusterTimeout = 60
+
+	}
+
 	//checks for Lock Refresh Time
 	//Rule is that LockRefreshTime should never be more than 3/4 of the LockClusterTimeout
 	{
@@ -214,6 +221,7 @@ func (conf *Configuration) SanityCheck() bool {
 	//check SSL path and certificates
 	if conf.Pxcluster.SslcertificatePath != "" {
 		Separator := string(os.PathSeparator)
+
 		//var failing = false
 		log.SetReportCaller(false)
 		if !CheckIfPathExists(conf.Pxcluster.SslcertificatePath) {

--- a/internal/Global/configuration.go
+++ b/internal/Global/configuration.go
@@ -136,14 +136,14 @@ func (conf *Configuration) SanityCheck() bool {
 	if conf.Pxcluster.MaxNumWriters > 1 &&
 		conf.Pxcluster.SinglePrimary {
 		log.SetReportCaller(true)
-		log.Fatal("Configuration error cannot have SinglePrimary true and MaxNumWriter >1")
+		log.Error("Configuration error cannot have SinglePrimary true and MaxNumWriter >1")
 		return false
 		//os.Exit(1)
 	}
 
 	if conf.Pxcluster.WriterIsAlsoReader != 1 && (conf.Pxcluster.MaxWriters > 1 || !conf.Pxcluster.SinglePrimary) {
 		log.SetReportCaller(true)
-		log.Fatal("Configuration error cannot have WriterIsAlsoReader NOT = 1 and use more than one Writer")
+		log.Error("Configuration error cannot have WriterIsAlsoReader NOT = 1 and use more than one Writer")
 		return false
 		//os.Exit(1)
 	}
@@ -189,7 +189,7 @@ func (conf *Configuration) SanityCheck() bool {
 		conf.Proxysql.LockFilePath = "/tmp"
 		if !CheckIfPathExists(conf.Proxysql.LockFilePath) {
 			log.SetReportCaller(true)
-			log.Fatal(fmt.Sprintf("LockFilePath is not accessible currently set to: |%s|", conf.Proxysql.LockFilePath))
+			log.Error(fmt.Sprintf("LockFilePath is not accessible currently set to: |%s|", conf.Proxysql.LockFilePath))
 			return false
 			//os.Exit(1)
 		}

--- a/internal/Global/configuration.go
+++ b/internal/Global/configuration.go
@@ -201,7 +201,7 @@ func (conf *Configuration) SanityCheck() bool {
 	{
 		lockCTO := int64(float64(conf.Global.LockClusterTimeout) * 0.75)
 		lockRFOrig := conf.Global.LockRefreshTime
-		if conf.Global.LockRefreshTime > lockCTO {
+		if conf.Global.LockRefreshTime > lockCTO || conf.Global.LockRefreshTime == 0 {
 			conf.Global.LockRefreshTime = lockCTO - 1
 			log.Warning(fmt.Sprintf("LockClusterTimeout (%d) exceeds the value of 3/4 LockClusterTimeout (%d). Value aggiusted to (%d) ",
 				lockRFOrig,

--- a/pxc_scheduler_handler.go
+++ b/pxc_scheduler_handler.go
@@ -30,7 +30,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var pxcSchedulerHandlerVersion = "1.4.3"
+var pxcSchedulerHandlerVersion = "1.5.3"
 
 /*
 Main function must contain only initial parameter, log system init and main object init

--- a/pxc_scheduler_handler.go
+++ b/pxc_scheduler_handler.go
@@ -30,7 +30,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var pxcSchedulerHandlerVersion = "1.5.3"
+var pxcSchedulerHandlerVersion = "1.5.0"
 
 /*
 Main function must contain only initial parameter, log system init and main object init


### PR DESCRIPTION
Currently when the proxysql cluster feature is activated scheduler update the epoch of the node owning the loc at each cycle.
This injects not needed writes that could create conflicts especially in an environment like k8. 

__solution__: Refresh epoch after few cycles but inside the `lockclustertimeout` value ideally every 3/4 of the `lockclustertimeout` value. 
Example:
scheduler loop every 2 seconds
`lockclustertimeout = 600 seconds`
`lockrefreshtime = 450` 

__Implementation__:
- add parameter `lockrefreshtime`
- add check for sanity for the parameter `lockrefreshtime` to never be higher than 3/4 of `lockclustertimeout`
- add a check in `findLock` method to return `true` only if  `lockrefreshtime` has been exceeded 
- add proper information in log (INFO)  

Also converting Fatal to Error when return value was present. 